### PR TITLE
Restore interval selection and multiple volatility metrics

### DIFF
--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -6,7 +6,12 @@ import argparse
 from pathlib import Path
 from typing import List, Optional
 
-from highest_volatility.compute.metrics import annualized_volatility
+import pandas as pd
+
+from highest_volatility.compute.metrics import (
+    additional_volatility_measures,
+    annualized_volatility,
+)
 from highest_volatility.ingest.prices import download_price_history
 from highest_volatility.ingest.tickers import fetch_fortune_tickers
 from highest_volatility.storage.csv_store import save_csv
@@ -17,18 +22,71 @@ DEFAULT_LOOKBACK_DAYS = 252
 DEFAULT_TOP_N = 100
 DEFAULT_PRINT_TOP = 5
 DEFAULT_MIN_DAYS = 126
+INTERVAL_CHOICES = ["1d", "60m", "30m", "15m", "5m", "1m"]
+METRIC_CHOICES = [
+    "cc_vol",
+    "parkinson_vol",
+    "gk_vol",
+    "rs_vol",
+    "yz_vol",
+    "ewma_vol",
+    "mad_vol",
+]
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command line arguments."""
 
-    parser = argparse.ArgumentParser(description="Find most volatile Fortune 100 stocks")
-    parser.add_argument("--lookback-days", type=int, default=DEFAULT_LOOKBACK_DAYS, help="Number of days of price history to use")
-    parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N, help="How many Fortune companies to analyse")
-    parser.add_argument("--print-top", type=int, default=DEFAULT_PRINT_TOP, help="How many results to print")
-    parser.add_argument("--min-days", type=int, default=DEFAULT_MIN_DAYS, help="Minimum data points required for a ticker")
-    parser.add_argument("--output-csv", type=Path, help="Optional path to write the full results as CSV")
-    parser.add_argument("--output-sqlite", type=Path, help="Optional path to write the full results to SQLite")
+    parser = argparse.ArgumentParser(
+        description="Find most volatile Fortune 100 stocks"
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help="Number of days of price history to use",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=DEFAULT_TOP_N,
+        help="How many Fortune companies to analyse",
+    )
+    parser.add_argument(
+        "--print-top",
+        type=int,
+        default=DEFAULT_PRINT_TOP,
+        help="How many results to print",
+    )
+    parser.add_argument(
+        "--min-days",
+        type=int,
+        default=DEFAULT_MIN_DAYS,
+        help="Minimum data points required for a ticker",
+    )
+    parser.add_argument(
+        "--interval",
+        choices=INTERVAL_CHOICES,
+        default="1d",
+        help="Price interval (daily or intraday)",
+    )
+    parser.add_argument(
+        "--metric",
+        choices=METRIC_CHOICES,
+        default="cc_vol",
+        help="Volatility metric to rank by",
+    )
+    parser.add_argument(
+        "--prepost",
+        action="store_true",
+        help="Include pre/post market data for intraday intervals",
+    )
+    parser.add_argument(
+        "--output-csv", type=Path, help="Optional path to write the full results as CSV"
+    )
+    parser.add_argument(
+        "--output-sqlite", type=Path, help="Optional path to write the full results to SQLite"
+    )
     return parser.parse_args(argv)
 
 
@@ -38,14 +96,28 @@ def main(argv: Optional[List[str]] = None) -> None:
     args = parse_args(argv)
     fortune = fetch_fortune_tickers(top_n=args.top_n)
     tickers = fortune["ticker"].tolist()
-    prices = download_price_history(tickers, args.lookback_days)
-    vols = annualized_volatility(prices, min_days=args.min_days).rename(
-        columns={"annualized_volatility": "volatility"}
+    prices = download_price_history(
+        tickers, args.lookback_days, interval=args.interval, prepost=args.prepost
     )
-    result = fortune.set_index("ticker").join(
-        vols.set_index("ticker")
-    ).dropna()
-    result = result.sort_values("volatility", ascending=False)
+    if isinstance(prices.columns, pd.MultiIndex):
+        if "Adj Close" in prices.columns.get_level_values(0):
+            close = prices["Adj Close"]
+        else:
+            close = prices["Close"]
+    else:
+        close = (
+            prices["Adj Close"] if "Adj Close" in prices.columns else prices["Close"]
+        )
+    vols_cc = annualized_volatility(
+        close, min_periods=args.min_days, interval=args.interval
+    ).rename(columns={"annualized_volatility": "cc_vol"})
+    extras = additional_volatility_measures(
+        prices, tickers, min_periods=args.min_days, interval=args.interval
+    )
+    vols = vols_cc.merge(extras, on="ticker", how="left")
+    result = fortune.set_index("ticker").join(vols.set_index("ticker"))
+    result = result.dropna(subset=[args.metric])
+    result = result.sort_values(args.metric, ascending=False)
 
     print(result.head(args.print_top).to_string())
 

--- a/src/highest_volatility/compute/__init__.py
+++ b/src/highest_volatility/compute/__init__.py
@@ -2,8 +2,11 @@
 
 from .metrics import (
     TRADING_DAYS_PER_YEAR,
+    TRADING_MINUTES_PER_DAY,
     annualized_volatility,
+    additional_volatility_measures,
     daily_returns,
+    periods_per_year,
     max_drawdown,
     rolling_volatility,
     sharpe_ratio,
@@ -11,8 +14,11 @@ from .metrics import (
 
 __all__ = [
     "TRADING_DAYS_PER_YEAR",
+    "TRADING_MINUTES_PER_DAY",
     "annualized_volatility",
+    "additional_volatility_measures",
     "daily_returns",
+    "periods_per_year",
     "max_drawdown",
     "rolling_volatility",
     "sharpe_ratio",

--- a/src/highest_volatility/compute/metrics.py
+++ b/src/highest_volatility/compute/metrics.py
@@ -10,8 +10,19 @@ consistent manner.
 
 import numpy as np
 import pandas as pd
+from typing import Dict, List
 
 TRADING_DAYS_PER_YEAR = 252
+TRADING_MINUTES_PER_DAY = 390
+
+
+def periods_per_year(interval: str) -> float:
+    """Return the number of observation periods in a year for a given interval."""
+
+    if interval.endswith("m"):
+        minutes = int(interval[:-1])
+        return TRADING_DAYS_PER_YEAR * TRADING_MINUTES_PER_DAY / minutes
+    return TRADING_DAYS_PER_YEAR
 
 
 def daily_returns(prices: pd.DataFrame) -> pd.DataFrame:
@@ -53,7 +64,10 @@ def daily_returns(prices: pd.DataFrame) -> pd.DataFrame:
 
 
 def annualized_volatility(
-    prices: pd.DataFrame, *, min_days: int | None = None
+    prices: pd.DataFrame,
+    *,
+    min_periods: int | None = None,
+    interval: str = "1d",
 ) -> pd.DataFrame:
     """Calculate annualized volatility for each ticker.
 
@@ -61,9 +75,12 @@ def annualized_volatility(
     ----------
     prices:
         Adjusted close prices with dates as index and tickers as columns.
-    min_days:
-        Optional minimum number of observations required for a ticker to
-        be included in the result.
+    min_periods:
+        Optional minimum number of observations required for a ticker to be
+        included in the result.
+    interval:
+        Interval used when fetching the data.  Determines the annualisation
+        factor.
 
     Returns
     -------
@@ -83,10 +100,10 @@ def annualized_volatility(
 
     log_returns = np.log(prices / prices.shift(1)).dropna(how="all")
     std_dev = log_returns.std(skipna=True)
-    if min_days is not None:
-        valid = log_returns.count() >= min_days
+    if min_periods is not None:
+        valid = log_returns.count() >= min_periods
         std_dev = std_dev[valid]
-    vols = std_dev * np.sqrt(TRADING_DAYS_PER_YEAR)
+    vols = std_dev * np.sqrt(periods_per_year(interval))
     return (
         vols.sort_values(ascending=False)
         .rename("annualized_volatility")
@@ -203,10 +220,155 @@ def sharpe_ratio(prices: pd.DataFrame, *, risk_free: float = 0.0) -> pd.DataFram
     return sharpe.rename("sharpe_ratio").rename_axis("ticker").reset_index()
 
 
+def additional_volatility_measures(
+    raw: pd.DataFrame,
+    tickers: List[str],
+    *,
+    min_periods: int = 2,
+    interval: str = "1d",
+    ewma_lambda: float = 0.94,
+) -> pd.DataFrame:
+    """Compute a selection of volatility estimators for each ticker.
+
+    Parameters
+    ----------
+    raw:
+        DataFrame as returned by :func:`yfinance.download` with OHLC data.
+    tickers:
+        Tickers for which to compute the metrics.
+    min_periods:
+        Minimum number of observations required to compute a metric.
+    interval:
+        Interval used when fetching the data.  Determines the annualisation
+        factor.
+    ewma_lambda:
+        Smoothing factor for the EWMA estimator.
+
+    Returns
+    -------
+    DataFrame
+        Columns ``ticker`` and any of ``parkinson_vol``, ``gk_vol``,
+        ``rs_vol``, ``yz_vol``, ``ewma_vol`` and ``mad_vol`` depending on the
+        available data.
+    """
+
+    per_year = periods_per_year(interval)
+    ln2 = np.log(2.0)
+    results: List[Dict[str, float]] = []
+
+    def _get_series(field: str, ticker: str) -> pd.Series | None:
+        try:
+            if isinstance(raw.columns, pd.MultiIndex):
+                return raw[field][ticker].dropna()
+            return raw[field].dropna()
+        except Exception:
+            return None
+
+    for t in tickers:
+        rec: Dict[str, float] = {"ticker": t}
+
+        s_close = _get_series("Adj Close", t)
+        if s_close is None:
+            s_close = _get_series("Close", t)
+        s_open = _get_series("Open", t)
+        s_high = _get_series("High", t)
+        s_low = _get_series("Low", t)
+
+        frames = {
+            k: v
+            for k, v in {
+                "close": s_close,
+                "open": s_open,
+                "high": s_high,
+                "low": s_low,
+            }.items()
+            if v is not None
+        }
+        if not frames or "close" not in frames:
+            continue
+
+        df = pd.DataFrame(frames).dropna()
+        if df.shape[0] < min_periods:
+            continue
+
+        r_cc = np.log(df["close"] / df["close"].shift(1)).dropna()
+
+        if {"high", "low"}.issubset(df.columns):
+            hl = np.log(df["high"] / df["low"]) ** 2
+            var = hl.mean() / (4.0 * ln2)
+            if np.isfinite(var) and var >= 0:
+                rec["parkinson_vol"] = float(np.sqrt(var * per_year))
+
+        if {"open", "high", "low", "close"}.issubset(df.columns):
+            log_hl = np.log(df["high"] / df["low"]) ** 2
+            log_co = np.log(df["close"] / df["open"]) ** 2
+            gk_var = 0.5 * log_hl.mean() - (2.0 * ln2 - 1.0) * log_co.mean()
+            if np.isfinite(gk_var) and gk_var >= 0:
+                rec["gk_vol"] = float(np.sqrt(gk_var * per_year))
+
+            term_rs = (
+                np.log(df["high"] / df["close"]) * np.log(df["high"] / df["open"]) +
+                np.log(df["low"] / df["close"]) * np.log(df["low"] / df["open"])
+            )
+            rs_var = term_rs.mean()
+            if np.isfinite(rs_var) and rs_var >= 0:
+                rec["rs_vol"] = float(np.sqrt(rs_var * per_year))
+
+            prev_close = df["close"].shift(1)
+            r_o = np.log(df["open"] / prev_close).dropna()
+            r_c = np.log(df["close"] / df["open"]).dropna()
+            df_rs = df.loc[r_c.index]
+            term_rs_d = (
+                np.log(df_rs["high"] / df_rs["close"]) * np.log(df_rs["high"] / df_rs["open"]) +
+                np.log(df_rs["low"] / df_rs["close"]) * np.log(df_rs["low"] / df_rs["open"])
+            )
+            sigma_o2 = r_o.var(ddof=1)
+            sigma_c2 = r_c.var(ddof=1)
+            sigma_rs = term_rs_d.mean()
+            if (
+                np.isfinite(sigma_o2)
+                and np.isfinite(sigma_c2)
+                and np.isfinite(sigma_rs)
+            ):
+                k = 0.34
+                yz_var = sigma_o2 + k * sigma_c2 + (1.0 - k) * sigma_rs
+                if yz_var >= 0:
+                    rec["yz_vol"] = float(np.sqrt(yz_var * per_year))
+
+        if r_cc.shape[0] >= min_periods:
+            var = r_cc.var(ddof=1) if r_cc.shape[0] >= 2 else float(r_cc.iloc[-1] ** 2)
+            for x in r_cc.iloc[-min_periods:]:
+                var = ewma_lambda * var + (1.0 - ewma_lambda) * (x * x)
+            if var >= 0:
+                rec["ewma_vol"] = float(np.sqrt(var * per_year))
+            mad = np.median(np.abs(r_cc - np.median(r_cc)))
+            rec["mad_vol"] = float(1.4826 * mad * np.sqrt(per_year))
+
+        results.append(rec)
+
+    out = pd.DataFrame(results)
+    if out.empty:
+        return out
+    cols = [
+        "ticker",
+        "parkinson_vol",
+        "gk_vol",
+        "rs_vol",
+        "yz_vol",
+        "ewma_vol",
+        "mad_vol",
+    ]
+    cols = [c for c in cols if c in out.columns]
+    return out[cols]
+
+
 __all__ = [
     "TRADING_DAYS_PER_YEAR",
+    "TRADING_MINUTES_PER_DAY",
     "daily_returns",
     "annualized_volatility",
+    "periods_per_year",
+    "additional_volatility_measures",
     "max_drawdown",
     "rolling_volatility",
     "sharpe_ratio",

--- a/src/highest_volatility/compute/volatility.py
+++ b/src/highest_volatility/compute/volatility.py
@@ -1,5 +1,5 @@
 """Backward compatibility wrappers for volatility functions."""
 
-from .metrics import annualized_volatility
+from .metrics import annualized_volatility, additional_volatility_measures
 
-__all__ = ["annualized_volatility"]
+__all__ = ["annualized_volatility", "additional_volatility_measures"]

--- a/src/highest_volatility/ingest/prices.py
+++ b/src/highest_volatility/ingest/prices.py
@@ -9,8 +9,14 @@ import pandas as pd
 import yfinance as yf
 
 
-def download_price_history(tickers: List[str], lookback_days: int) -> pd.DataFrame:
-    """Download adjusted close prices for ``tickers``.
+def download_price_history(
+    tickers: List[str],
+    lookback_days: int,
+    *,
+    interval: str = "1d",
+    prepost: bool = False,
+) -> pd.DataFrame:
+    """Download price history for ``tickers``.
 
     Parameters
     ----------
@@ -18,19 +24,27 @@ def download_price_history(tickers: List[str], lookback_days: int) -> pd.DataFra
         List of ticker symbols compatible with Yahoo Finance.
     lookback_days:
         Number of calendar days of history to request.
+    interval:
+        Data interval supported by Yahoo Finance (e.g. ``1d``, ``60m``, ``15m``).
+    prepost:
+        Include pre/post market data for intraday intervals.
 
     Returns
     -------
     pandas.DataFrame
-        DataFrame indexed by date with one column per ticker.
+        Raw DataFrame as returned by :func:`yfinance.download`.
     """
 
     end = datetime.utcnow()
     start = end - timedelta(days=lookback_days * 2)
     ticker_str = " ".join(tickers)
-    data = yf.download(ticker_str, start=start, end=end, progress=False, auto_adjust=True)
-    if isinstance(data.columns, pd.MultiIndex):
-        data = data["Close"]
-    else:
-        data = data.to_frame(name="Close")
+    data = yf.download(
+        ticker_str,
+        start=start,
+        end=end,
+        interval=interval,
+        progress=False,
+        auto_adjust=False,
+        prepost=prepost,
+    )
     return data.dropna(how="all")


### PR DESCRIPTION
## Summary
- allow fetching price history at configurable intervals like 15m, 30m, 60m
- compute several volatility estimators (Parkinson, Garman-Klass, Rogers-Satchell, Yang-Zhang, EWMA, MAD)
- extend CLI with --interval and --metric options

## Testing
- `PYTHONPATH=src python -m highest_volatility --help`
- `PYTHONPATH=src python -m highest_volatility --top-n 1 --print-top 1 --lookback-days 30 --min-days 5 --interval 1d`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c48a19f5448328a038e74aa364d8d9