### PR TITLE
chore: schedule Fortune 500 ticker scrape

### DIFF
--- a/.github/workflows/update-fortune-tickers.yml
+++ b/.github/workflows/update-fortune-tickers.yml
@@ -1,0 +1,27 @@
+name: Update Fortune 500 tickers
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Fetch Fortune 500 tickers
+        run: |
+          python scripts/scrape_fortune_500_tickers.py
+      - name: Upload ticker list
+        uses: actions/upload-artifact@v3
+        with:
+          name: fortune-500-tickers
+          path: fortune500_tickers.csv

--- a/scripts/scrape_fortune_500_tickers.py
+++ b/scripts/scrape_fortune_500_tickers.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from highest_volatility.ingest.tickers import fetch_fortune_tickers
+from highest_volatility.storage.csv_store import save_csv
+
+OUTPUT_FILE = ROOT / "fortune500_tickers.csv"
+
+
+def main() -> None:
+    table = fetch_fortune_tickers(top_n=500)
+    save_csv(table, OUTPUT_FILE)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scrape latest Fortune 500 tickers and save to CSV
- add monthly GitHub Action to fetch and upload ticker list

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c48c603668832892a018a9de6df651