### PR TITLE
feat: cache fortune tickers

### DIFF
--- a/src/highest_volatility/ingest/tickers.py
+++ b/src/highest_volatility/ingest/tickers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import json
+import time
+from pathlib import Path
 
 import pandas as pd
 import requests
@@ -20,7 +22,11 @@ class FortuneTicker:
     ticker: str
 
 
+# Default source and cache configuration
 DEFAULT_SOURCE_URL = "https://us500.com/fortune-500-companies"
+CACHE_DIR = Path(".cache") / "tickers"
+CACHE_FILE = "fortune.json"
+CACHE_EXPIRY = 24 * 60 * 60  # one day
 FALLBACK_TICKERS = [
     FortuneTicker(1, "Apple", "AAPL"),
     FortuneTicker(2, "Microsoft", "MSFT"),
@@ -37,36 +43,88 @@ def normalize_ticker(ticker: str) -> str:
     return t.replace(".", "-")
 
 
-def fetch_fortune_tickers(source_url: str = DEFAULT_SOURCE_URL, *, top_n: int = 100) -> pd.DataFrame:
+def fetch_fortune_tickers(
+    source_url: str = DEFAULT_SOURCE_URL,
+    *,
+    top_n: int = 100,
+    cache_dir: Path | str = CACHE_DIR,
+    cache_expiry: int = CACHE_EXPIRY,
+    session: requests.Session | None = None,
+) -> pd.DataFrame:
     """Fetch the Fortune company list and return the first *top_n* rows.
 
-    The primary data source is ``us500.com`` which renders its table via
-    JavaScript.  To avoid introducing a full browser dependency, we parse the
-    ``__NEXT_DATA__`` JSON blob embedded in the page which contains the
-    information for the first 50 companies.  If anything goes wrong a small
-    built-in fallback list is returned instead.
+    Results are cached on disk in ``.cache/tickers`` to avoid repeated
+    network requests.  The primary data source is ``us500.com`` which renders
+    its table via JavaScript.  We parse the ``__NEXT_DATA__`` JSON blob
+    embedded in the page and iterate over all pages until the full list has
+    been collected.  If anything goes wrong a small built-in fallback list is
+    returned instead.
     """
 
-    headers = {"User-Agent": "Mozilla/5.0"}
+    cache_path = Path(cache_dir) / CACHE_FILE
+
+    # Attempt to use cached data if still valid
     try:
-        response = requests.get(source_url, timeout=30, headers=headers)
-        response.raise_for_status()
-        soup = BeautifulSoup(response.text, "html.parser")
-        script = soup.find("script", id="__NEXT_DATA__")
-        if script and script.string:
-            data = json.loads(script.string)
-            companies = data["props"]["pageProps"].get("initialResults", [])
-            if companies:
-                table = pd.DataFrame(companies)
-                table = table.rename(columns=str.lower)
-                expected_cols = {"rank", "company", "ticker"}
-                table = table[list(expected_cols)].head(top_n)
-                table["rank"] = table["rank"].astype(int)
-                table["ticker"] = table["ticker"].astype(str).map(normalize_ticker)
-                table = table[table["ticker"].str.fullmatch(r"[A-Z]+[A-Z0-9.-]*")]  # drop entries without a valid ticker
-                return table.reset_index(drop=True)
+        if cache_path.exists():
+            with cache_path.open() as fh:
+                payload = json.load(fh)
+            if time.time() - payload.get("timestamp", 0) < cache_expiry:
+                table = pd.DataFrame(payload.get("data", []))
+                if not table.empty:
+                    table = table.rename(columns=str.lower)
+                    table["rank"] = table["rank"].astype(int)
+                    table["ticker"] = table["ticker"].astype(str).map(normalize_ticker)
+                    table = table[table["ticker"].str.fullmatch(r"[A-Z]+[A-Z0-9.-]*")]
+                    return table.sort_values("rank").head(top_n).reset_index(drop=True)
     except Exception:
         pass
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+    session = session or requests
+    results: list[dict] = []
+    page = 1
+    total = None
+    try:
+        while True:
+            url = source_url if page == 1 else f"{source_url}?page={page}"
+            response = session.get(url, timeout=30, headers=headers)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+            script = soup.find("script", id="__NEXT_DATA__")
+            if not script or not script.string:
+                break
+            data = json.loads(script.string)
+            page_data = data["props"]["pageProps"].get("initialResults", [])
+            if not page_data:
+                break
+            results.extend(page_data)
+            stats = data["props"]["pageProps"].get("stats", {})
+            total = total or stats.get("ffc")
+            if (total and len(results) >= total) or len(results) >= top_n:
+                break
+            page += 1
+    except Exception:
+        results = []
+
+    if results:
+        table = pd.DataFrame(results)
+        table = table.rename(columns=str.lower)
+        expected_cols = {"rank", "company", "ticker"}
+        table = table[list(expected_cols)]
+        table["rank"] = table["rank"].astype(int)
+        table["ticker"] = table["ticker"].astype(str).map(normalize_ticker)
+        table = table[table["ticker"].str.fullmatch(r"[A-Z]+[A-Z0-9.-]*")]
+        table = table.sort_values("rank").head(top_n).reset_index(drop=True)
+
+        # Store to cache
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            with cache_path.open("w") as fh:
+                json.dump({"timestamp": time.time(), "data": table.to_dict(orient="records")}, fh)
+        except Exception:
+            pass
+
+        return table
 
     fallback_df = pd.DataFrame([f.__dict__ for f in FALLBACK_TICKERS])
     return fallback_df.head(top_n)

--- a/tests/test_tickers_cache.py
+++ b/tests/test_tickers_cache.py
@@ -1,0 +1,81 @@
+import json
+import time
+from pathlib import Path
+
+import pandas as pd
+
+from highest_volatility.ingest import tickers
+
+
+def _build_page(companies, total=None):
+    total = total if total is not None else len(companies)
+    data = {
+        "props": {"pageProps": {"initialResults": companies, "stats": {"ffc": total}}}
+    }
+    return f"<html><script id='__NEXT_DATA__'>{json.dumps(data)}</script></html>"
+
+
+class _Resp:
+    def __init__(self, text):
+        self.text = text
+        self.status_code = 200
+
+    def raise_for_status(self):  # pragma: no cover - simple stub
+        pass
+
+
+class DummySession:
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def get(self, url, timeout=30, headers=None):
+        self.calls.append(url)
+        page = 1
+        if "page=" in url:
+            page = int(url.split("page=")[1])
+        html = self.pages.get(page)
+        if html is None:
+            raise AssertionError("unexpected page")
+        return _Resp(html)
+
+
+def test_cached_list_used_when_available(tmp_path):
+    pages = {
+        1: _build_page(
+            [
+                {"rank": 1, "company": "A", "ticker": "AAA"},
+                {"rank": 2, "company": "B", "ticker": "BBB"},
+            ],
+            total=3,
+        ),
+        2: _build_page([{ "rank": 3, "company": "C", "ticker": "CCC" }], total=3),
+    }
+    session1 = DummySession(pages)
+
+    df1 = tickers.fetch_fortune_tickers(top_n=3, cache_dir=tmp_path, session=session1)
+    assert len(df1) == 3
+    assert len(session1.calls) == 2
+
+    session2 = DummySession({})
+    df2 = tickers.fetch_fortune_tickers(top_n=3, cache_dir=tmp_path, session=session2)
+    assert session2.calls == []  # served from cache
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+def test_cached_list_refreshed_after_expiry(tmp_path):
+    initial_pages = {1: _build_page([{"rank": 1, "company": "A", "ticker": "AAA"}])}
+    session = DummySession(initial_pages)
+    df1 = tickers.fetch_fortune_tickers(top_n=1, cache_dir=tmp_path, session=session)
+    assert df1.iloc[0]["company"] == "A"
+
+    cache_file = Path(tmp_path) / tickers.CACHE_FILE
+    payload = json.loads(cache_file.read_text())
+    payload["timestamp"] = time.time() - tickers.CACHE_EXPIRY - 1
+    cache_file.write_text(json.dumps(payload))
+
+    updated_pages = {1: _build_page([{"rank": 1, "company": "X", "ticker": "XXX"}])}
+    session_new = DummySession(updated_pages)
+    df2 = tickers.fetch_fortune_tickers(top_n=1, cache_dir=tmp_path, session=session_new)
+    assert session_new.calls  # network was used
+    assert df2.iloc[0]["company"] == "X"


### PR DESCRIPTION
## Summary
- cache Fortune tickers to `.cache/tickers` with expiry
- paginate through all pages to retrieve the full Fortune list
- tests for cache usage and refresh on expiry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c49de78b0c8328bb05d2a99c144b42