### PR TITLE
Fetch all US500 tickers from Next.js data API

### DIFF
--- a/tests/test_tickers_cache.py
+++ b/tests/test_tickers_cache.py
@@ -7,15 +7,25 @@ import pandas as pd
 from highest_volatility.ingest import tickers
 
 
-def _build_page(companies, total=None):
+BUILD_ID = "build123"
+
+
+def _build_html_page(companies, total=None):
+    """Return a minimal HTML document containing the ``__NEXT_DATA__`` blob."""
     total = total if total is not None else len(companies)
     data = {
-        "props": {"pageProps": {"initialResults": companies, "stats": {"ffc": total}}}
+        "buildId": BUILD_ID,
+        "props": {"pageProps": {"initialResults": companies, "stats": {"ffc": total}}},
     }
     return f"<html><script id='__NEXT_DATA__'>{json.dumps(data)}</script></html>"
 
 
-class _Resp:
+def _build_json_page(companies):
+    """Return the JSON payload served by the ``_next/data`` endpoint."""
+    return {"pageProps": {"initialResults": companies}}
+
+
+class _HTMLResp:
     def __init__(self, text):
         self.text = text
         self.status_code = 200
@@ -24,48 +34,66 @@ class _Resp:
         pass
 
 
+class _JSONResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def json(self):  # pragma: no cover - simple stub
+        return self._data
+
+    def raise_for_status(self):  # pragma: no cover - simple stub
+        pass
+
+
 class DummySession:
-    def __init__(self, pages):
-        self.pages = pages
+    """Simple session stub that serves pre-defined HTML/JSON pages."""
+
+    def __init__(self, html_page, json_pages):
+        self.html_page = html_page
+        self.json_pages = json_pages
         self.calls = []
 
     def get(self, url, timeout=30, headers=None):
         self.calls.append(url)
-        page = 1
-        if "page=" in url:
+        if "fortune-500-companies.json" in url:
             page = int(url.split("page=")[1])
-        html = self.pages.get(page)
-        if html is None:
+            data = self.json_pages.get(page)
+            if data is None:
+                raise AssertionError("unexpected page")
+            return _JSONResp(data)
+        if self.html_page is None:
             raise AssertionError("unexpected page")
-        return _Resp(html)
+        return _HTMLResp(self.html_page)
 
 
 def test_cached_list_used_when_available(tmp_path):
-    pages = {
-        1: _build_page(
-            [
-                {"rank": 1, "company": "A", "ticker": "AAA"},
-                {"rank": 2, "company": "B", "ticker": "BBB"},
-            ],
-            total=3,
-        ),
-        2: _build_page([{ "rank": 3, "company": "C", "ticker": "CCC" }], total=3),
-    }
-    session1 = DummySession(pages)
+    html_page = _build_html_page(
+        [
+            {"rank": 1, "company": "A", "ticker": "AAA"},
+            {"rank": 2, "company": "B", "ticker": "BBB"},
+        ],
+        total=3,
+    )
+    json_pages = {2: _build_json_page([{ "rank": 3, "company": "C", "ticker": "CCC" }])}
+    session1 = DummySession(html_page, json_pages)
 
     df1 = tickers.fetch_fortune_tickers(top_n=3, cache_dir=tmp_path, session=session1)
     assert len(df1) == 3
     assert len(session1.calls) == 2
+    assert session1.calls[1].endswith(
+        f"/_next/data/{BUILD_ID}/fortune-500-companies.json?page=2"
+    )
 
-    session2 = DummySession({})
+    session2 = DummySession(None, {})
     df2 = tickers.fetch_fortune_tickers(top_n=3, cache_dir=tmp_path, session=session2)
     assert session2.calls == []  # served from cache
     pd.testing.assert_frame_equal(df1, df2)
 
 
 def test_cached_list_refreshed_after_expiry(tmp_path):
-    initial_pages = {1: _build_page([{"rank": 1, "company": "A", "ticker": "AAA"}])}
-    session = DummySession(initial_pages)
+    html_page = _build_html_page([{"rank": 1, "company": "A", "ticker": "AAA"}])
+    session = DummySession(html_page, {})
     df1 = tickers.fetch_fortune_tickers(top_n=1, cache_dir=tmp_path, session=session)
     assert df1.iloc[0]["company"] == "A"
 
@@ -74,8 +102,9 @@ def test_cached_list_refreshed_after_expiry(tmp_path):
     payload["timestamp"] = time.time() - tickers.CACHE_EXPIRY - 1
     cache_file.write_text(json.dumps(payload))
 
-    updated_pages = {1: _build_page([{"rank": 1, "company": "X", "ticker": "XXX"}])}
-    session_new = DummySession(updated_pages)
+    updated_html = _build_html_page([{"rank": 1, "company": "X", "ticker": "XXX"}])
+    session_new = DummySession(updated_html, {})
     df2 = tickers.fetch_fortune_tickers(top_n=1, cache_dir=tmp_path, session=session_new)
     assert session_new.calls  # network was used
     assert df2.iloc[0]["company"] == "X"
+


### PR DESCRIPTION
## Summary
- Parse Next.js `__NEXT_DATA__` to obtain build ID and total company count
- Page through `/__next/data/...` JSON endpoints to collect all Fortune tickers
- Adjust ticker cache tests to exercise new JSON workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4a226adbc8328b13c9449cce9bd38