### PR TITLE
Add universe size guard and handle pct_change warning

### DIFF
--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -15,7 +15,7 @@ from highest_volatility.compute.metrics import (
     sharpe_ratio,
 )
 from highest_volatility.ingest.prices import download_price_history
-from highest_volatility.ingest.tickers import fetch_fortune_tickers
+from highest_volatility.universe import build_universe
 from highest_volatility.storage.csv_store import save_csv
 from highest_volatility.storage.sqlite_store import save_sqlite
 
@@ -98,8 +98,12 @@ def main(argv: Optional[List[str]] = None) -> None:
     """Entry point for the CLI."""
 
     args = parse_args(argv)
-    fortune = fetch_fortune_tickers(top_n=args.top_n)
-    tickers = fortune["ticker"].tolist()
+    tickers, fortune = build_universe(args.top_n)
+    if len(tickers) < args.print_top:
+        raise SystemExit(
+            f"Universe too small: got {len(tickers)} tickers, but --print-top={args.print_top}. "
+            "Check pagination / fetch source."
+        )
     prices = download_price_history(
         tickers, args.lookback_days, interval=args.interval, prepost=args.prepost
     )

--- a/src/highest_volatility/compute/metrics.py
+++ b/src/highest_volatility/compute/metrics.py
@@ -54,7 +54,7 @@ def daily_returns(prices: pd.DataFrame) -> pd.DataFrame:
     >>> pd.testing.assert_frame_equal(daily_returns(prices), expected)
     """
 
-    returns = prices.pct_change().iloc[1:]
+    returns = prices.pct_change(fill_method=None).iloc[1:]
     return (
         returns.stack()
         .rename("daily_return")
@@ -212,7 +212,7 @@ def sharpe_ratio(prices: pd.DataFrame, *, risk_free: float = 0.0) -> pd.DataFram
     {'ticker': {0: 'A'}, 'sharpe_ratio': {0: 6.73}}
     """
 
-    returns = prices.pct_change().dropna()
+    returns = prices.pct_change(fill_method=None).dropna()
     excess = returns - risk_free / TRADING_DAYS_PER_YEAR
     mean = excess.mean()
     std = returns.std()

--- a/src/highest_volatility/universe.py
+++ b/src/highest_volatility/universe.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Utilities for building the ticker universe.
+
+This module fetches the Fortune list, normalises tickers and ensures the
+resulting universe is deduplicated.  It logs the final size so callers can
+verify that enough data was retrieved before continuing with expensive
+processing.
+"""
+
+import logging
+from typing import Tuple
+
+import pandas as pd
+
+from .ingest.tickers import fetch_fortune_tickers
+
+logger = logging.getLogger(__name__)
+
+
+def build_universe(first_n_fortune: int) -> Tuple[list[str], pd.DataFrame]:
+    """Return a deduplicated list of tickers and the Fortune table.
+
+    Parameters
+    ----------
+    first_n_fortune:
+        Number of Fortune 500 entries to fetch.
+
+    Returns
+    -------
+    list[str]
+        Ticker symbols in the order they appeared.
+    DataFrame
+        Original Fortune table for the requested slice.
+    """
+
+    table = fetch_fortune_tickers(top_n=first_n_fortune)
+    tickers = [t for t in table["ticker"].tolist() if t]
+    seen = set()
+    deduped: list[str] = []
+    for t in tickers:
+        if t in seen:
+            continue
+        deduped.append(t)
+        seen.add(t)
+
+    logger.info("Universe size after fetch/dedupe: %d", len(deduped))
+    return deduped, table

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,9 @@ def test_cli_rank_by_sharpe_ratio(monkeypatch, capsys):
     prices, fortune = _mock_data()
 
     monkeypatch.setattr(
-        cli, "fetch_fortune_tickers", lambda top_n: fortune.head(top_n)
+        cli,
+        "build_universe",
+        lambda top_n: (fortune["ticker"].head(top_n).tolist(), fortune.head(top_n)),
     )
     monkeypatch.setattr(
         cli,
@@ -45,7 +47,9 @@ def test_cli_rank_by_max_drawdown(monkeypatch, capsys):
     prices, fortune = _mock_data()
 
     monkeypatch.setattr(
-        cli, "fetch_fortune_tickers", lambda top_n: fortune.head(top_n)
+        cli,
+        "build_universe",
+        lambda top_n: (fortune["ticker"].head(top_n).tolist(), fortune.head(top_n)),
     )
     monkeypatch.setattr(
         cli,

--- a/tests/test_cli_guard.py
+++ b/tests/test_cli_guard.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from highest_volatility.app import cli
+
+
+def test_cli_fails_if_universe_too_small(monkeypatch):
+    fortune = pd.DataFrame(
+        {"rank": [1, 2], "company": ["A", "B"], "ticker": ["A", "B"]}
+    )
+
+    def fake_build(_top_n):
+        return fortune["ticker"].tolist(), fortune
+
+    monkeypatch.setattr(cli, "build_universe", fake_build)
+    monkeypatch.setattr(
+        cli,
+        "download_price_history",
+        lambda tickers, lookback_days, interval="1d", prepost=False: pd.DataFrame(),
+    )
+
+    with pytest.raises(SystemExit, match="Universe too small"):
+        cli.main(["--top-n", "2", "--print-top", "3"])

--- a/tests/test_universe_size.py
+++ b/tests/test_universe_size.py
@@ -1,0 +1,34 @@
+from highest_volatility import universe
+from highest_volatility.ingest import tickers
+from tests.test_tickers_cache import (
+    BUILD_ID,
+    DummySession,
+    _build_html_page,
+    _build_json_page,
+)
+
+
+def test_universe_can_fetch_over_200(monkeypatch, tmp_path):
+    # Prepare five pages with 50 unique tickers each (total 250)
+    first_page = [
+        {"rank": i + 1, "company": f"C{i}", "ticker": f"T{i}"} for i in range(50)
+    ]
+    html_page = _build_html_page(first_page, total=250)
+    json_pages = {}
+    for page in range(2, 6):
+        start = (page - 1) * 50
+        comps = [
+            {"rank": start + j + 1, "company": f"C{start + j}", "ticker": f"T{start + j}"}
+            for j in range(50)
+        ]
+        json_pages[page] = _build_json_page(comps)
+    session = DummySession(html_page, json_pages)
+
+    def fake_fetch(top_n):
+        return tickers.fetch_fortune_tickers(
+            top_n=top_n, cache_dir=tmp_path, session=session
+        )
+
+    monkeypatch.setattr(universe, "fetch_fortune_tickers", fake_fetch)
+    tickers_list, _fortune = universe.build_universe(300)
+    assert len(tickers_list) >= 200


### PR DESCRIPTION
## Summary
- Add `build_universe` helper to fetch and dedupe Fortune tickers while logging universe size
- Enforce minimum universe size in CLI and exit early when insufficient tickers are retrieved
- Silence pandas `pct_change` deprecation warning
- Add regression tests for pagination and CLI guard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4aae00f2c8328b3aa9fdcbd1d1d4f