### PR TITLE
Add async price fetching and CLI flag

### DIFF
--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -131,6 +131,11 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         default=8,
         help="Max parallel workers for price fetching",
     )
+    parser.add_argument(
+        "--async-fetch",
+        action="store_true",
+        help="Fetch prices asynchronously via HTTP API",
+    )
     return parser.parse_args(argv)
 
 
@@ -166,7 +171,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         use_cache=args.use_cache,
         force_refresh=args.force_refresh_prices,
         max_workers=args.price_fetch_workers,
-        matrix_mode="batch",
+        matrix_mode="async" if args.async_fetch else "batch",
     )
     timings["download_prices"] = time.perf_counter() - t0
     if isinstance(prices.columns, pd.MultiIndex):

--- a/tests/test_prices_async.py
+++ b/tests/test_prices_async.py
@@ -1,0 +1,31 @@
+import pandas as pd
+
+from highest_volatility.ingest import prices
+from datetime import date, datetime
+
+
+class FakeAsyncDS:
+    async def get_prices(self, ticker, start, end, interval):
+        idx = pd.date_range("2020-01-01", periods=3)
+        return pd.DataFrame({"Adj Close": [1, 2, 3]}, index=idx)
+
+
+def test_download_price_history_async(monkeypatch):
+    class D(date):
+        @classmethod
+        def today(cls):
+            return date(2020, 1, 6)
+
+    class DT(datetime):
+        @classmethod
+        def utcnow(cls):
+            return datetime(2020, 1, 6)
+
+    monkeypatch.setattr(prices, "date", D)
+    monkeypatch.setattr(prices, "datetime", DT)
+    monkeypatch.setattr(prices, "YahooAsyncDataSource", lambda: FakeAsyncDS())
+
+    df = prices.download_price_history(["AAA", "BBB"], 5, matrix_mode="async", use_cache=False)
+    assert set(df.columns.get_level_values(1)) == {"AAA", "BBB"}
+    assert "Adj Close" in df.columns.get_level_values(0)
+


### PR DESCRIPTION
## Summary
- Implement async price retrieval using YahooAsyncDataSource with Semaphore and gather
- Add `--async-fetch` CLI flag to enable async mode
- Include tests for async price download and CLI flag handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c57e912e6c8328a10e51363c0ac52a