### PR TITLE
Add retry controls for Yahoo downloads

### DIFF
--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -132,6 +132,12 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Max parallel workers for price fetching",
     )
     parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=3,
+        help="Maximum retry attempts for price downloads",
+    )
+    parser.add_argument(
         "--async-fetch",
         action="store_true",
         help="Fetch prices asynchronously via HTTP API",
@@ -172,6 +178,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         force_refresh=args.force_refresh_prices,
         max_workers=args.price_fetch_workers,
         matrix_mode="async" if args.async_fetch else "batch",
+        max_retries=args.max_retries,
     )
     timings["download_prices"] = time.perf_counter() - t0
     if isinstance(prices.columns, pd.MultiIndex):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,3 +102,33 @@ def test_cli_async_flag(monkeypatch):
     ])
     assert called.get("matrix_mode") == "async"
 
+
+def test_cli_passes_max_retries(monkeypatch):
+    prices, fortune = _mock_data()
+    called = {}
+
+    def _mock_download(*args, **kwargs):
+        called["max_retries"] = kwargs.get("max_retries")
+        return prices
+
+    monkeypatch.setattr(
+        cli,
+        "build_universe",
+        lambda top_n, **__: (fortune["ticker"].head(top_n).tolist(), fortune.head(top_n)),
+    )
+    monkeypatch.setattr(cli, "download_price_history", _mock_download)
+
+    cli.main([
+        "--metric",
+        "sharpe_ratio",
+        "--top-n",
+        "2",
+        "--print-top",
+        "2",
+        "--min-days",
+        "2",
+        "--max-retries",
+        "7",
+    ])
+    assert called.get("max_retries") == 7
+


### PR DESCRIPTION
## Summary
- wrap all yfinance downloads with tenacity retries and exponential backoff
- add optional pause between batch chunks
- expose --max-retries option in CLI and forward to download logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5806dc0f08328a66a62d4e9dd6a73