### PR TITLE
Add daily price fetcher with repo cache hydration

### DIFF
--- a/.github/workflows/daily-price-fetch.yml
+++ b/.github/workflows/daily-price-fetch.yml
@@ -1,0 +1,29 @@
+name: Daily price fetch
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Fetch prices with retry
+        run: |
+          intervals=(1m 5m 10m 15m 30m 60m 1d)
+          tickers="AAPL MSFT AMZN GOOGL META"
+          for intv in "${intervals[@]}"; do
+            until python -m src.cli --interval "$intv" --tickers $tickers; do
+              echo "Retrying $intv..."
+              sleep 30
+            done
+          done

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ selenium-stealth
 pyarrow
 pytest
 aiohttp
+tenacity

--- a/src/cache/store.py
+++ b/src/cache/store.py
@@ -7,8 +7,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 import json
+import os
+import subprocess
 
 import pandas as pd
+import requests
 
 CACHE_ROOT = Path(".cache/prices")
 
@@ -30,12 +33,68 @@ def _paths(ticker: str, interval: str) -> Tuple[Path, Path]:
     return base / f"{ticker}.parquet", base / f"{ticker}.json"
 
 
+def _hydrate_from_repo(ticker: str, interval: str, parquet_path: Path, manifest_path: Path) -> None:
+    """Attempt to download cached data from the GitHub repository.
+
+    This is used for local runs to hydrate the on-disk cache before falling
+    back to fresh downloads.  It is a best-effort helper and silently returns
+    if any step fails or if the files are unavailable upstream.
+    """
+
+    try:
+        remote_url = (
+            subprocess.run(
+                ["git", "config", "--get", "remote.origin.url"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        )
+    except Exception:
+        return
+
+    if remote_url.endswith(".git"):
+        remote_url = remote_url[:-4]
+    if remote_url.startswith("git@github.com:"):
+        owner_repo = remote_url.split("git@github.com:", 1)[1]
+    elif remote_url.startswith("https://github.com/"):
+        owner_repo = remote_url.split("https://github.com/", 1)[1]
+    else:
+        return
+
+    owner_repo = owner_repo.strip("/")
+    branch = os.getenv("CACHE_REPO_BRANCH", "main")
+    base = (
+        f"https://raw.githubusercontent.com/{owner_repo}/{branch}/.cache/prices/{interval}/{ticker}"
+    )
+
+    targets = [
+        (parquet_path, base + ".parquet", "b"),
+        (manifest_path, base + ".json", "t"),
+    ]
+    for path, url, mode in targets:
+        try:
+            r = requests.get(url, timeout=10)
+            if r.status_code != 200:
+                return
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if mode == "b":
+                path.write_bytes(r.content)
+            else:
+                path.write_text(r.text)
+        except Exception:
+            return
+
+
 def load_cached(ticker: str, interval: str) -> Tuple[Optional[pd.DataFrame], Optional[Manifest]]:
     """Load cached prices and manifest for ``ticker``/``interval``."""
 
     parquet_path, manifest_path = _paths(ticker, interval)
     if not parquet_path.exists() or not manifest_path.exists():
-        return None, None
+        if os.getenv("GITHUB_ACTIONS") != "true":
+            _hydrate_from_repo(ticker, interval, parquet_path, manifest_path)
+        if not parquet_path.exists() or not manifest_path.exists():
+            return None, None
 
     df = pd.read_parquet(parquet_path)
     if not isinstance(df.index, pd.DatetimeIndex):


### PR DESCRIPTION
## Summary
- Hydrate local price cache from GitHub repo before fetching new data
- Schedule daily GitHub Action to fetch quotes across multiple intervals with retries
- Include missing tenacity dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c581d35bd083289dfe150dde7a44de