### PR TITLE
Add cache refresh scheduler and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Highest Volatility
+
+Tools for exploring equity price volatility.  The project includes utilities for
+loading and caching price history.
+
+## Cache Refresh
+
+A helper script is provided to refresh cached price data for all locally stored
+tickers.  It iterates over the tickers under `.cache/prices/<interval>` and
+updates each one sequentially.
+
+Run the scheduler from the repository root:
+
+```bash
+python scripts/refresh_cache.py
+```
+
+By default the script refreshes once per day.  To run it on a regular schedule
+using cron, add an entry similar to:
+
+```
+0 0 * * * cd /path/to/repo && /usr/bin/python scripts/refresh_cache.py >> refresh.log 2>&1
+```
+
+Adjust the interval and paths as needed.

--- a/scripts/refresh_cache.py
+++ b/scripts/refresh_cache.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""CLI to launch periodic cache refresh."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from highest_volatility.pipeline.cache_refresh import schedule_cache_refresh
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Refresh cached price data periodically")
+    parser.add_argument("--interval", default="1d", help="Price interval to refresh (default: 1d)")
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=365,
+        help="Number of lookback days for each ticker (default: 365)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=int,
+        default=60 * 60 * 24,
+        help="Seconds between refresh runs (default: one day)",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(
+        schedule_cache_refresh(
+            interval=args.interval, lookback_days=args.lookback_days, delay=args.delay
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/highest_volatility/pipeline/__init__.py
+++ b/src/highest_volatility/pipeline/__init__.py
@@ -1,0 +1,3 @@
+"""Background tasks for refreshing cached price data."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add async helpers to refresh cached prices and schedule periodic runs
- add CLI script to launch cache refresh scheduler
- document cache refresh and cron usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5eab148948328a89d7da0d021d1dc