### PR TITLE
Add Value at Risk and Sortino ratio metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 Tools for exploring equity price volatility.  The project includes utilities for
 loading and caching price history.
 
+## Metrics
+
+The command line interface exposes a number of built-in metrics that can be
+selected with the ``--metric`` option:
+
+- ``cc_vol`` – close-to-close annualised volatility
+- ``parkinson_vol`` – Parkinson's high-low estimator
+- ``gk_vol`` – Garman–Klass volatility
+- ``rs_vol`` – Rogers–Satchell volatility
+- ``yz_vol`` – Yang–Zhang volatility
+- ``ewma_vol`` – exponentially weighted moving average volatility
+- ``mad_vol`` – median absolute deviation volatility
+- ``sharpe_ratio`` – annualised Sharpe ratio
+- ``max_drawdown`` – maximum drawdown
+- ``var`` – value at risk (VaR)
+- ``sortino`` – annualised Sortino ratio
+
 ## Cache Refresh
 
 A helper script is provided to refresh cached price data for all locally stored

--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -66,7 +66,10 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         "--metric",
         choices=METRIC_CHOICES,
         default="cc_vol",
-        help="Metric to rank by",
+        help=(
+            "Metric to rank by (e.g. cc_vol, sharpe_ratio, max_drawdown, "
+            "var, sortino)"
+        ),
     )
     parser.add_argument(
         "--prepost",

--- a/tests/test_metric_plugins.py
+++ b/tests/test_metric_plugins.py
@@ -25,3 +25,45 @@ METRICS = {'my_metric': my_metric}
     importlib.reload(metrics)
     metrics.load_plugins()
     assert 'my_metric' in metrics.METRIC_REGISTRY
+
+
+def _sample_price_matrix() -> pd.DataFrame:
+    idx = pd.date_range("2020-01-01", periods=5)
+    close = pd.DataFrame(
+        {
+            "A": [100, 110, 105, 102, 100],
+            "B": [100, 90, 95, 94, 96],
+        },
+        index=idx,
+    )
+    return pd.concat({"Adj Close": close}, axis=1)
+
+
+def test_value_at_risk_metric():
+    prices = _sample_price_matrix()
+    result = metrics.METRIC_REGISTRY["var"](prices)
+    expected = pd.DataFrame(
+        {
+            "ticker": ["A", "B"],
+            "var": [-0.042922, -0.086579],
+        }
+    )
+    pd.testing.assert_frame_equal(
+        result.sort_values("ticker").reset_index(drop=True).round(6),
+        expected,
+    )
+
+
+def test_sortino_metric():
+    prices = _sample_price_matrix()
+    result = metrics.METRIC_REGISTRY["sortino"](prices)
+    expected = pd.DataFrame(
+        {
+            "ticker": ["A", "B"],
+            "sortino": [1.925098, -2.113560],
+        }
+    )
+    pd.testing.assert_frame_equal(
+        result.sort_values("ticker").reset_index(drop=True).round(6),
+        expected,
+    )


### PR DESCRIPTION
## Summary
- implement Value at Risk and Sortino ratio metrics on closing prices
- expose new metrics via CLI and document them in README
- cover metrics with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ec8999b08328bde9341b71c76928