### PR TITLE
Add background cache refresh and configurable interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ selected with the ``--metric`` option:
 
 ## Cache Refresh
 
+A background task runs when the API starts, periodically refreshing cached
+price data for any locally stored tickers. The interval between refreshes is
+configured with the ``HV_CACHE_REFRESH_INTERVAL`` environment variable and
+defaults to once every 24 hours.
+
 A helper script is provided to refresh cached price data for all locally stored
 tickers.  It iterates over the tickers under `.cache/prices/<interval>` and
 updates each one sequentially.


### PR DESCRIPTION
## Summary
- import `schedule_cache_refresh` and run it on startup in a background task
- add `cache_refresh_interval` setting to control the refresh schedule
- document automatic cache refresh in API via `HV_CACHE_REFRESH_INTERVAL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f00729948328858b2dfb4f4af6da