### PR TITLE
Add lightweight data API and Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 Tools for exploring equity price volatility.  The project includes utilities for
 loading and caching price history.
 
+## Data API
+
+A lightweight FastAPI service exposes cached price data and the Fortune ticker
+universe. Build and run it with Docker:
+
+```bash
+docker build -t hv-api .
+docker run -p 8000:8000 hv-api
+```
+
+The service provides two endpoints:
+
+- ``/prices/{ticker}`` – return cached prices for ``ticker``. Use the ``fmt``
+  query parameter to request ``json`` (default) or ``parquet`` bytes.
+- ``/fortune-tickers`` – return the cached Fortune 500 ticker list.
+
+Client utilities such as ``cache.store`` will hydrate missing local cache files
+from this API when the ``HV_API_BASE_URL`` environment variable is set.
+
 ## Metrics
 
 The command line interface exposes a number of built-in metrics that can be

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+
+from fastapi import FastAPI, HTTPException, Response
+
+from cache.store import load_cached
+from highest_volatility.storage.ticker_cache import load_cached_fortune
+
+app = FastAPI(title="Highest Volatility Data API")
+
+
+@app.get("/prices/{ticker}")
+def get_prices(
+    ticker: str,
+    interval: str = "1d",
+    fmt: str = "json",
+):
+    ticker = ticker.upper()
+    df, _ = load_cached(ticker, interval)
+    if df is None:
+        raise HTTPException(status_code=404, detail="Ticker not found")
+
+    if fmt == "json":
+        return json.loads(df.to_json(orient="split", date_format="iso"))
+    if fmt == "parquet":
+        buf = BytesIO()
+        df.to_parquet(buf)
+        return Response(
+            buf.getvalue(),
+            media_type="application/x-parquet",
+            headers={"Content-Disposition": f"attachment; filename={ticker}_{interval}.parquet"},
+        )
+    raise HTTPException(status_code=400, detail="Unknown format")
+
+
+@app.get("/fortune-tickers")
+def get_fortune_tickers(fmt: str = "json"):
+    df = load_cached_fortune()
+    if df is None:
+        raise HTTPException(status_code=404, detail="Fortune list not available")
+
+    if fmt == "json":
+        return {"tickers": df["ticker"].dropna().tolist()}
+    if fmt == "parquet":
+        buf = BytesIO()
+        df.to_parquet(buf)
+        return Response(
+            buf.getvalue(),
+            media_type="application/x-parquet",
+            headers={"Content-Disposition": "attachment; filename=fortune_tickers.parquet"},
+        )
+    raise HTTPException(status_code=400, detail="Unknown format")


### PR DESCRIPTION
## Summary
- expose cached prices and Fortune ticker list via FastAPI under `src/api`
- hydrate local cache from API instead of GitHub raw files
- provide Dockerfile and docs for running the API service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b228d3cc8328a6124953e4a82d04