### PR TITLE
Add cache validation and tests for price cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ webdriver-manager
 selenium-stealth
 pyarrow
 pytest
+pytest-asyncio
 aiohttp
 tenacity
 fastapi

--- a/src/highest_volatility/pipeline/__init__.py
+++ b/src/highest_volatility/pipeline/__init__.py
@@ -1,3 +1,5 @@
 """Background tasks for refreshing cached price data."""
 
-__all__ = []
+from .validation import validate_cache
+
+__all__ = ["validate_cache"]

--- a/src/highest_volatility/pipeline/validation.py
+++ b/src/highest_volatility/pipeline/validation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Validation utilities for cached price data."""
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from cache.store import Manifest
+
+FREQ_MAP = {
+    "1m": "1min",
+    "5m": "5min",
+    "10m": "10min",
+    "15m": "15min",
+    "30m": "30min",
+    "60m": "60min",
+    "1h": "60min",
+    "1wk": "W",
+    "1mo": "M",
+}
+
+DELTA_MAP = {
+    "1m": pd.Timedelta("1min"),
+    "5m": pd.Timedelta("5min"),
+    "10m": pd.Timedelta("10min"),
+    "15m": pd.Timedelta("15min"),
+    "30m": pd.Timedelta("30min"),
+    "60m": pd.Timedelta("60min"),
+    "1h": pd.Timedelta("60min"),
+    "1d": pd.Timedelta("1D"),
+}
+
+
+def validate_cache(df: pd.DataFrame, manifest: "Manifest") -> None:
+    """Validate cached DataFrame against its manifest.
+
+    Parameters
+    ----------
+    df:
+        Price data to validate.
+    manifest:
+        Manifest describing the cached data.
+
+    Raises
+    ------
+    ValueError
+        If any validation check fails.
+    """
+
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("DataFrame index must be DatetimeIndex")
+    if not df.index.is_monotonic_increasing or df.index.has_duplicates:
+        raise ValueError("Index must be unique and sorted")
+    if df.isna().any().any():
+        raise ValueError("Data contains NaNs")
+
+    start = pd.to_datetime(manifest.start)
+    end = pd.to_datetime(manifest.end)
+    if df.index.min().date() != start.date() or df.index.max().date() != end.date():
+        raise ValueError("Index range does not match manifest")
+    if len(df) != manifest.rows:
+        raise ValueError("Row count mismatch with manifest")
+
+    try:
+        freq = pd.infer_freq(df.index) if len(df.index) >= 3 else None
+    except ValueError:
+        freq = None
+    freq = freq or FREQ_MAP.get(manifest.interval)
+    if freq:
+        if (manifest.interval.endswith("m") and manifest.interval != "1mo") or freq.endswith("T") or freq.endswith("min"):
+            for _, group in df.groupby(df.index.date):
+                expected = pd.date_range(group.index.min(), group.index.max(), freq=freq)
+                if len(expected) != len(group):
+                    raise ValueError("Gap detected in index")
+        else:
+            expected = pd.date_range(df.index.min(), df.index.max(), freq=freq)
+            if len(expected) != len(df):
+                raise ValueError("Gap detected in index")
+    else:
+        delta = DELTA_MAP.get(manifest.interval)
+        if delta is not None and not df.index.to_series().diff().dropna().le(delta).all():
+            raise ValueError("Gap detected in index")

--- a/tests/test_cache_validation.py
+++ b/tests/test_cache_validation.py
@@ -1,0 +1,79 @@
+import pandas as pd
+import pytest
+
+from cache import store
+from highest_volatility.pipeline import validate_cache
+
+
+def _make_df():
+    idx = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"])
+    return pd.DataFrame({"Adj Close": [1.0, 2.0, 3.0]}, index=idx)
+
+
+def _make_manifest(df):
+    return store.Manifest(
+        ticker="ABC",
+        interval="1d",
+        start=str(df.index[0].date()),
+        end=str(df.index[-1].date()),
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+
+
+def test_validate_cache_ok():
+    df = _make_df()
+    manifest = _make_manifest(df)
+    validate_cache(df, manifest)  # should not raise
+
+
+def test_validate_cache_nan():
+    df = _make_df()
+    df.iloc[1, 0] = None
+    manifest = _make_manifest(df)
+    with pytest.raises(ValueError):
+        validate_cache(df, manifest)
+
+
+def test_validate_cache_gap():
+    idx = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-04", "2020-01-05"])
+    df = pd.DataFrame({"Adj Close": [1.0, 2.0, 4.0, 5.0]}, index=idx)
+    manifest = store.Manifest(
+        ticker="ABC",
+        interval="1d",
+        start=str(df.index[0].date()),
+        end=str(df.index[-1].date()),
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+    with pytest.raises(ValueError):
+        validate_cache(df, manifest)
+
+
+def test_validate_cache_range_mismatch():
+    df = _make_df()
+    manifest = store.Manifest(
+        ticker="ABC",
+        interval="1d",
+        start="2020-01-01",
+        end="2020-01-02",
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+    with pytest.raises(ValueError):
+        validate_cache(df, manifest)
+
+
+def test_save_cache_uses_validator(tmp_path, monkeypatch):
+    monkeypatch.setattr(store, "CACHE_ROOT", tmp_path)
+    df = _make_df()
+    df.iloc[1, 0] = None
+    with pytest.raises(ValueError):
+        store.save_cache("ABC", "1d", df, "test")
+    assert not (tmp_path / "1d" / "ABC.parquet").exists()


### PR DESCRIPTION
## Summary
- validate cached price data to ensure no gaps, NaNs, or index mismatches
- invoke cache validation from `save_cache` before writing files
- add tests for cache validator and add pytest-asyncio requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6b6f961b88328938b59d6ad57c6f5