### PR TITLE
Add Streamlit dashboard configuration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ selected with the ``--metric`` option:
 - ``var`` – value at risk (VaR)
 - ``sortino`` – annualised Sortino ratio
 
+## Streamlit App
+
+An interactive dashboard is available via Streamlit. It mirrors the CLI
+defaults, letting you pick the lookback window, interval, metric, and minimum
+observation count directly from the sidebar. Additional toggles allow skipping
+Selenium validation of the Fortune universe and opting into asynchronous price
+fetching.
+
+Launch the UI with:
+
+```bash
+streamlit run src/highest_volatility/app/streamlit_app.py
+```
+
+Results are displayed as a sortable table with warning banners when price data
+is unavailable for the selected configuration.
+
 ## Cache Refresh
 
 A background task runs when the API starts, periodically refreshing cached

--- a/src/highest_volatility/app/streamlit_app.py
+++ b/src/highest_volatility/app/streamlit_app.py
@@ -1,0 +1,176 @@
+"""Streamlit application entry point for Highest Volatility."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+import streamlit as st
+
+from highest_volatility.app.cli import (
+    DEFAULT_LOOKBACK_DAYS,
+    DEFAULT_MIN_DAYS,
+    DEFAULT_TOP_N,
+    INTERVAL_CHOICES,
+    METRIC_CHOICES,
+)
+from highest_volatility.app.ui_helpers import (
+    prepare_metric_table,
+    sanitize_price_matrix,
+)
+from highest_volatility.ingest.prices import download_price_history
+from highest_volatility.universe import build_universe
+
+
+st.set_page_config(page_title="Highest Volatility", layout="wide")
+
+st.title("Highest Volatility Explorer")
+st.caption(
+    "Interactively explore Fortune-listed tickers using the built-in metrics."
+)
+
+
+with st.sidebar:
+    st.header("Configuration")
+    top_n = st.slider(
+        "Universe size",
+        min_value=10,
+        max_value=500,
+        step=10,
+        value=DEFAULT_TOP_N,
+        help="Number of Fortune companies to analyse.",
+    )
+    lookback_days = st.number_input(
+        "Lookback window (days)",
+        min_value=30,
+        max_value=2000,
+        value=DEFAULT_LOOKBACK_DAYS,
+        step=5,
+    )
+    interval = st.selectbox("Interval", INTERVAL_CHOICES, index=0)
+    metric_key = st.selectbox("Metric", METRIC_CHOICES, index=0)
+    min_days = st.number_input(
+        "Minimum observations per ticker",
+        min_value=10,
+        max_value=lookback_days,
+        value=DEFAULT_MIN_DAYS,
+        step=5,
+    )
+    prepost = st.checkbox(
+        "Include pre/post-market data",
+        value=False,
+        help="Enable to include extended-hours data for intraday intervals.",
+    )
+    validate_universe = st.checkbox(
+        "Validate tickers via Selenium",
+        value=True,
+        help="Disable to skip validation for faster startup (uses cached tickers when available).",
+    )
+    async_fetch = st.checkbox(
+        "Fetch prices asynchronously",
+        value=False,
+        help="Use the experimental async HTTP fetcher instead of batch downloads.",
+    )
+    run_analysis = st.button("Run analysis", type="primary")
+
+
+@st.cache_data(show_spinner=False)
+def _build_universe_cached(
+    top_n: int, validate: bool
+) -> tuple[list[str], pd.DataFrame]:
+    tickers, fortune = build_universe(top_n, validate=validate)
+    return tickers, fortune
+
+
+@st.cache_data(show_spinner=False)
+def _download_prices_cached(
+    tickers: Sequence[str],
+    lookback_days: int,
+    interval: str,
+    prepost: bool,
+    matrix_mode: str,
+) -> pd.DataFrame:
+    return download_price_history(
+        list(tickers),
+        lookback_days,
+        interval=interval,
+        prepost=prepost,
+        matrix_mode=matrix_mode,
+    )
+
+
+def _render() -> None:
+    if not run_analysis:
+        st.info("Adjust the configuration and click **Run analysis** to fetch data.")
+        return
+
+    with st.spinner("Building Fortune universe…"):
+        tickers, fortune = _build_universe_cached(top_n, validate_universe)
+
+    if not tickers:
+        st.warning("No tickers were returned by the universe builder.")
+        return
+
+    with st.spinner("Downloading price history…"):
+        prices = _download_prices_cached(
+            tuple(tickers),
+            lookback_days,
+            interval,
+            prepost,
+            "async" if async_fetch else "batch",
+        )
+
+    if prices.empty:
+        st.warning("Price history request returned no data for the selected options.")
+        return
+
+    filtered_prices, close_only, dropped_short, dropped_duplicate, dropped_empty = (
+        sanitize_price_matrix(prices, min_days=min_days, tickers=tickers)
+    )
+
+    if close_only.empty:
+        st.warning(
+            "All tickers were filtered out due to insufficient history or duplicate data."
+        )
+        return
+
+    dropped_msgs = []
+    if dropped_short:
+        dropped_msgs.append(
+            f"{len(dropped_short)} tickers lacked the required {min_days} observations."
+        )
+    if dropped_duplicate:
+        dropped_msgs.append(
+            f"{len(dropped_duplicate)} tickers were removed due to duplicate price series."
+        )
+    if dropped_empty:
+        dropped_msgs.append(
+            f"{len(dropped_empty)} tickers contained only empty values after cleaning."
+        )
+    if dropped_msgs:
+        st.info("\n".join(dropped_msgs))
+
+    try:
+        table = prepare_metric_table(
+            filtered_prices,
+            metric_key=metric_key,
+            min_days=min_days,
+            interval=interval,
+            tickers=close_only.columns,
+            fortune=fortune,
+            close_prices=close_only,
+        )
+    except Exception as exc:  # pragma: no cover - surface to UI
+        st.error(f"Failed to compute metric: {exc}")
+        return
+
+    if table.empty:
+        st.warning("Metric computation returned no rows for the selected configuration.")
+        return
+
+    metric_label = metric_key.replace("_", " ").title()
+    st.subheader(f"Top tickers by {metric_label}")
+    st.dataframe(table, use_container_width=True)
+
+
+_render()

--- a/src/highest_volatility/app/ui_helpers.py
+++ b/src/highest_volatility/app/ui_helpers.py
@@ -1,0 +1,155 @@
+"""Utilities to support the Streamlit frontend for Highest Volatility."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Sequence
+
+import pandas as pd
+
+from highest_volatility.compute.metrics import METRIC_REGISTRY
+
+
+def extract_close_frame(
+    prices: pd.DataFrame, *, tickers: Sequence[str] | None = None
+) -> pd.DataFrame:
+    """Return a DataFrame of adjusted close prices keyed by ticker symbol."""
+
+    if prices.empty:
+        return pd.DataFrame()
+
+    if isinstance(prices.columns, pd.MultiIndex):
+        level0 = prices.columns.get_level_values(0)
+        field = "Adj Close" if "Adj Close" in level0 else "Close"
+        close = prices[field]
+        return close.copy()
+
+    field = "Adj Close" if "Adj Close" in prices.columns else "Close"
+    if field not in prices.columns:
+        return pd.DataFrame()
+
+    close = prices[[field]].copy()
+    if tickers and len(tickers) == 1:
+        close.columns = [tickers[0]]
+    else:
+        name = tickers[0] if tickers else field
+        close.columns = [name]
+    return close
+
+
+def sanitize_price_matrix(
+    prices: pd.DataFrame,
+    *,
+    min_days: int,
+    tickers: Sequence[str] | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, list[str], list[str], list[str]]:
+    """Return a sanitized price matrix and close-only DataFrame.
+
+    The helper mirrors the CLI behaviour by ensuring that:
+    - columns with insufficient history are removed;
+    - duplicate price series (recent tails) are dropped; and
+    - the original price matrix only contains tickers that survived sanitisation.
+    """
+
+    close = extract_close_frame(prices, tickers=tickers)
+    if close.empty:
+        return prices.iloc[0:0], close, [], [], []
+
+    close = close.loc[:, ~close.columns.duplicated(keep="first")]
+
+    dropped_short: list[str] = []
+    keep_columns: list[str] = []
+    for column in close.columns:
+        if int(close[column].notna().sum()) >= min_days:
+            keep_columns.append(column)
+        else:
+            dropped_short.append(column)
+
+    working = close[keep_columns].copy()
+
+    dropped_empty: list[str] = []
+    dropped_duplicate: list[str] = []
+    tail_n = min(250, max(60, min_days))
+    seen: dict[str, str] = {}
+    for column in list(working.columns):
+        series = working[column].tail(tail_n).astype(float).ffill().bfill()
+        if series.dropna().empty:
+            working = working.drop(columns=[column])
+            dropped_empty.append(column)
+            continue
+        digest = hashlib.sha1(series.to_numpy().tobytes()).hexdigest()
+        if digest in seen:
+            working = working.drop(columns=[column])
+            dropped_duplicate.append(column)
+        else:
+            seen[digest] = column
+
+    keep_tickers = list(working.columns)
+    if isinstance(prices.columns, pd.MultiIndex):
+        mask = prices.columns.get_level_values(1).isin(keep_tickers)
+        filtered = prices.loc[:, mask].copy()
+    else:
+        filtered = prices.copy()
+
+    return filtered, working, dropped_short, dropped_duplicate, dropped_empty
+
+
+def prepare_metric_table(
+    prices: pd.DataFrame,
+    *,
+    metric_key: str,
+    min_days: int,
+    interval: str,
+    tickers: Sequence[str],
+    fortune: pd.DataFrame | None,
+    close_prices: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Compute the requested metric and return a formatted table."""
+
+    if metric_key not in METRIC_REGISTRY:
+        raise KeyError(f"Unknown metric '{metric_key}'")
+
+    if prices.empty:
+        return pd.DataFrame()
+
+    metric_func = METRIC_REGISTRY[metric_key]
+
+    extra_kwargs: dict[str, pd.DataFrame] = {}
+    if close_prices is not None and not close_prices.empty:
+        extra_kwargs["close"] = close_prices
+
+    metrics = metric_func(
+        prices,
+        tickers=list(tickers),
+        min_periods=min_days,
+        interval=interval,
+        **extra_kwargs,
+    )
+    if metrics.empty:
+        return metrics
+
+    metrics = metrics.drop_duplicates(subset=["ticker"], keep="first")
+    metrics = metrics.set_index("ticker")
+
+    table = metrics
+    if fortune is not None and not fortune.empty:
+        fortune_clean = fortune.drop_duplicates(subset=["ticker"]).set_index("ticker")
+        cols: list[str] = []
+        for name in ("rank", "company"):
+            if name in fortune_clean.columns:
+                cols.append(name)
+        if cols:
+            table = fortune_clean[cols].join(table, how="inner")
+
+    table = table.reset_index()
+    if metric_key in table.columns:
+        table = table.sort_values(metric_key, ascending=False)
+
+    return table.reset_index(drop=True)
+
+
+__all__ = [
+    "extract_close_frame",
+    "sanitize_price_matrix",
+    "prepare_metric_table",
+]

--- a/tests/test_ui_helpers.py
+++ b/tests/test_ui_helpers.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import pytest
+
+from highest_volatility.app.ui_helpers import (
+    prepare_metric_table,
+    sanitize_price_matrix,
+)
+
+
+@pytest.fixture
+def sample_prices() -> pd.DataFrame:
+    idx = pd.date_range("2022-01-01", periods=6, freq="D")
+    data = {
+        ("Adj Close", "AAA"): [100, 101, 102, 104, 103, 105],
+        ("Adj Close", "BBB"): [50, 49, 48, 47, 46, 45],
+    }
+    return pd.DataFrame(data, index=idx)
+
+
+def test_sanitize_price_matrix_filters_short_series(sample_prices: pd.DataFrame) -> None:
+    prices = sample_prices.copy()
+    prices[("Adj Close", "BBB")] = [50, pd.NA, pd.NA, pd.NA, pd.NA, pd.NA]
+
+    filtered, close_only, dropped_short, dropped_duplicate, dropped_empty = (
+        sanitize_price_matrix(prices, min_days=3, tickers=["AAA", "BBB"])
+    )
+
+    assert list(close_only.columns) == ["AAA"]
+    assert dropped_short == ["BBB"]
+    assert dropped_duplicate == []
+    assert dropped_empty == []
+    assert (
+        filtered.columns.get_level_values(1).tolist() == ["AAA"]
+    ), "Only the surviving ticker should remain"
+
+
+def test_prepare_metric_table_sorts_and_joins(sample_prices: pd.DataFrame) -> None:
+    fortune = pd.DataFrame(
+        {
+            "rank": [1, 2],
+            "company": ["Alpha", "Bravo"],
+            "ticker": ["AAA", "BBB"],
+        }
+    )
+    filtered, close_only, *_ = sanitize_price_matrix(
+        sample_prices, min_days=3, tickers=["AAA", "BBB"]
+    )
+
+    table = prepare_metric_table(
+        filtered,
+        metric_key="cc_vol",
+        min_days=3,
+        interval="1d",
+        tickers=close_only.columns,
+        fortune=fortune,
+        close_prices=close_only,
+    )
+
+    assert list(table.columns) == ["ticker", "rank", "company", "cc_vol"]
+    assert table.shape[0] == 2
+    assert table.loc[0, "cc_vol"] >= table.loc[1, "cc_vol"]
+    assert table.loc[table["ticker"] == "AAA", "company"].iloc[0] == "Alpha"
+
+
+def test_prepare_metric_table_handles_empty_prices() -> None:
+    table = prepare_metric_table(
+        pd.DataFrame(),
+        metric_key="cc_vol",
+        min_days=5,
+        interval="1d",
+        tickers=[],
+        fortune=None,
+    )
+    assert table.empty
+
+
+def test_prepare_metric_table_unknown_metric(sample_prices: pd.DataFrame) -> None:
+    with pytest.raises(KeyError):
+        prepare_metric_table(
+            sample_prices,
+            metric_key="unknown",
+            min_days=3,
+            interval="1d",
+            tickers=["AAA"],
+            fortune=None,
+        )


### PR DESCRIPTION
## Summary
- add a Streamlit UI that mirrors the CLI defaults and exposes configuration toggles
- factor out reusable helpers to prepare metric tables and sanitize price data for the UI
- document the new dashboard and cover helpers with tests that ensure sorting and filtering behaviour

## Testing
- PYTHONPATH=src pytest tests/test_ui_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68cd675f4e6c832880b39872dfdc2695