### PR TITLE
Refactor Streamlit analysis flow into modular helpers

### DIFF
--- a/src/highest_volatility/app/streamlit_app.py
+++ b/src/highest_volatility/app/streamlit_app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
@@ -25,10 +26,54 @@ from highest_volatility.app.cli import (
     INTERVAL_CHOICES,
     METRIC_CHOICES,
 )
-from highest_volatility.app.ui_helpers import prepare_metric_table, sanitize_price_matrix
+from highest_volatility.app.ui_helpers import (
+    SanitizedPrices,
+    prepare_metric_table,
+    sanitize_price_matrix,
+)
 from highest_volatility.compute.metrics import max_drawdown, rolling_volatility
 from highest_volatility.ingest.prices import download_price_history
 from highest_volatility.universe import build_universe
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisConfig:
+    """Immutable container describing the current UI configuration."""
+
+    top_n: int
+    lookback_days: int
+    interval: str
+    metric_key: str
+    min_days: int
+    prepost: bool
+    validate_universe: bool
+    async_fetch: bool
+
+    @property
+    def matrix_mode(self) -> str:
+        """Return the price download mode based on async preference."""
+
+        return "async" if self.async_fetch else "batch"
+
+
+@dataclass(frozen=True, slots=True)
+class UniverseData:
+    """Result of building the Fortune universe."""
+
+    tickers: list[str]
+    fortune: pd.DataFrame | None
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.tickers
+
+    def fortune_view(self) -> pd.DataFrame:
+        if self.fortune is None or self.fortune.empty:
+            return pd.DataFrame()
+        columns = [col for col in ("rank", "company", "ticker") if col in self.fortune.columns]
+        if not columns:
+            return pd.DataFrame()
+        return self.fortune.loc[:, columns]
 
 
 st.set_page_config(page_title="Highest Volatility", layout="wide")
@@ -82,6 +127,17 @@ with st.sidebar:
     )
     run_analysis = st.button("Run analysis", type="primary")
 
+config = AnalysisConfig(
+    top_n=top_n,
+    lookback_days=lookback_days,
+    interval=interval,
+    metric_key=metric_key,
+    min_days=min_days,
+    prepost=prepost,
+    validate_universe=validate_universe,
+    async_fetch=async_fetch,
+)
+
 
 @st.cache_data(show_spinner=False)
 def _build_universe_cached(
@@ -108,99 +164,91 @@ def _download_prices_cached(
     )
 
 
-def _render() -> None:
-    if not run_analysis:
-        st.info("Adjust the configuration and click **Run analysis** to fetch data.")
-        return
+def _ensure_analysis_requested(run_requested: bool) -> bool:
+    if run_requested:
+        return True
+    st.info("Adjust the configuration and click **Run analysis** to fetch data.")
+    return False
 
+
+def _load_universe(config: AnalysisConfig) -> UniverseData | None:
     with st.spinner("Building Fortune universe…"):
-        tickers, fortune = _build_universe_cached(top_n, validate_universe)
-
-    if not tickers:
+        tickers, fortune = _build_universe_cached(config.top_n, config.validate_universe)
+    universe = UniverseData(list(tickers), fortune)
+    if universe.is_empty:
         st.warning("No tickers were returned by the universe builder.")
+        return None
+    return universe
+
+
+def _render_universe_section(universe: UniverseData) -> None:
+    view = universe.fortune_view()
+    if view.empty:
         return
-
-    if fortune is not None and not fortune.empty:
-        universe_view = fortune.loc[:, [col for col in ("rank", "company", "ticker") if col in fortune.columns]]
-        if not universe_view.empty:
-            st.subheader("Fortune universe")
-            st.dataframe(universe_view, use_container_width=True)
-            st.download_button(
-                "Download universe (CSV)",
-                data=universe_view.to_csv(index=False),
-                file_name="fortune_universe.csv",
-                mime="text/csv",
-            )
-
-    with st.spinner("Downloading price history…"):
-        prices = _download_prices_cached(
-            tuple(tickers),
-            lookback_days,
-            interval,
-            prepost,
-            "async" if async_fetch else "batch",
-        )
-
-    if prices.empty:
-        st.warning("Price history request returned no data for the selected options.")
-        return
-
-    filtered_prices, close_only, dropped_short, dropped_duplicate, dropped_empty = (
-        sanitize_price_matrix(prices, min_days=min_days, tickers=tickers)
+    st.subheader("Fortune universe")
+    st.dataframe(view, use_container_width=True)
+    st.download_button(
+        "Download universe (CSV)",
+        data=view.to_csv(index=False),
+        file_name="fortune_universe.csv",
+        mime="text/csv",
     )
 
-    if close_only.empty:
-        st.warning(
-            "All tickers were filtered out due to insufficient history or duplicate data."
-        )
-        return
 
-    dropped_msgs = []
-    if dropped_short:
-        dropped_msgs.append(
-            f"{len(dropped_short)} tickers lacked the required {min_days} observations."
+def _download_prices_for(universe: UniverseData, config: AnalysisConfig) -> pd.DataFrame:
+    with st.spinner("Downloading price history…"):
+        return _download_prices_cached(
+            tuple(universe.tickers),
+            config.lookback_days,
+            config.interval,
+            config.prepost,
+            config.matrix_mode,
         )
-    if dropped_duplicate:
-        dropped_msgs.append(
-            f"{len(dropped_duplicate)} tickers were removed due to duplicate price series."
-        )
-    if dropped_empty:
-        dropped_msgs.append(
-            f"{len(dropped_empty)} tickers contained only empty values after cleaning."
-        )
-    if dropped_msgs:
-        st.info("\n".join(dropped_msgs))
 
+
+def _sanitize_prices_for(
+    prices: pd.DataFrame, config: AnalysisConfig, universe: UniverseData
+) -> SanitizedPrices:
+    return sanitize_price_matrix(
+        prices,
+        min_days=config.min_days,
+        tickers=universe.tickers,
+    )
+
+
+def _display_drop_messages(sanitized: SanitizedPrices, config: AnalysisConfig) -> None:
+    messages = sanitized.summarize_drops(min_days=config.min_days)
+    if messages:
+        st.info("\n".join(messages))
+
+
+def _compute_metric_table(
+    config: AnalysisConfig, sanitized: SanitizedPrices, fortune: pd.DataFrame | None
+) -> pd.DataFrame:
     try:
-        table = prepare_metric_table(
-            filtered_prices,
-            metric_key=metric_key,
-            min_days=min_days,
-            interval=interval,
-            tickers=close_only.columns,
+        return prepare_metric_table(
+            sanitized.filtered,
+            metric_key=config.metric_key,
+            min_days=config.min_days,
+            interval=config.interval,
+            tickers=sanitized.available_tickers,
             fortune=fortune,
-            close_prices=close_only,
+            close_prices=sanitized.close_only,
         )
     except Exception as exc:  # pragma: no cover - surface to UI
         st.error(f"Failed to compute metric: {exc}")
-        return
+        return pd.DataFrame()
 
-    if table.empty:
-        st.warning("Metric computation returned no rows for the selected configuration.")
-        return
 
+def _render_metric_table(table: pd.DataFrame, metric_key: str) -> None:
     metric_label = metric_key.replace("_", " ").title()
     st.subheader(f"Top tickers by {metric_label}")
-
     highlight_n = min(10, len(table))
-
     styled_table = table.style.apply(
         lambda row: ["background-color: #fff3cd" if row.name < highlight_n else "" for _ in row],
         axis=1,
     )
-
     st.dataframe(styled_table, use_container_width=True)
-
     st.download_button(
         "Download metric ranking (CSV)",
         data=table.to_csv(index=False),
@@ -208,74 +256,127 @@ def _render() -> None:
         mime="text/csv",
     )
 
-    available_tickers = list(close_only.columns)
+
+def _select_visualised_tickers(
+    table: pd.DataFrame, sanitized: SanitizedPrices
+) -> list[str]:
+    available = sanitized.available_tickers
+    if not available or "ticker" not in table.columns:
+        return []
     default_selection = table["ticker"].head(min(5, len(table))).tolist()
-    selected_tickers = st.multiselect(
+    return st.multiselect(
         "Tickers to visualize",
-        options=available_tickers,
-        default=[ticker for ticker in default_selection if ticker in available_tickers],
+        options=available,
+        default=[ticker for ticker in default_selection if ticker in available],
     )
 
-    tabs = st.tabs(["Metrics & Prices", "Drawdowns", "Rolling Volatility"])
 
+def _render_price_history(close_only: pd.DataFrame, selected_tickers: list[str]) -> None:
+    if not selected_tickers:
+        st.info("Select at least one ticker to display the price chart.")
+        return
+    price_history = (
+        close_only[selected_tickers]
+        .rename_axis("date")
+        .reset_index()
+        .melt(id_vars="date", var_name="ticker", value_name="close")
+    )
+    price_chart = (
+        alt.Chart(price_history)
+        .mark_line()
+        .encode(x="date:T", y="close:Q", color="ticker:N")
+        .properties(height=400)
+    )
+    st.altair_chart(price_chart, use_container_width=True)
+
+
+def _render_drawdown_history(close_only: pd.DataFrame, selected_tickers: list[str]) -> None:
+    if not selected_tickers:
+        st.info("Select at least one ticker to review drawdowns.")
+        return
+    drawdown = close_only[selected_tickers] / close_only[selected_tickers].cummax() - 1
+    drawdown_long = (
+        drawdown.rename_axis("date")
+        .reset_index()
+        .melt(id_vars="date", var_name="ticker", value_name="drawdown")
+    )
+    drawdown_chart = (
+        alt.Chart(drawdown_long)
+        .mark_line()
+        .encode(x="date:T", y=alt.Y("drawdown:Q", title="Drawdown"), color="ticker:N")
+        .properties(height=400)
+    )
+    st.altair_chart(drawdown_chart, use_container_width=True)
+    drawdown_summary = max_drawdown(close_only[selected_tickers])
+    st.dataframe(drawdown_summary, use_container_width=True)
+
+
+def _render_rolling_volatility(close_only: pd.DataFrame, selected_tickers: list[str]) -> None:
+    if not selected_tickers:
+        st.info("Select at least one ticker to inspect rolling volatility.")
+        return
+    rolling = rolling_volatility(close_only[selected_tickers])
+    rolling_chart = (
+        alt.Chart(rolling)
+        .mark_line()
+        .encode(
+            x="date:T",
+            y=alt.Y("rolling_volatility:Q", title="Annualized Volatility"),
+            color="ticker:N",
+            strokeDash=alt.StrokeDash("window:N", title="Window"),
+        )
+        .properties(height=400)
+    )
+    st.altair_chart(rolling_chart, use_container_width=True)
+
+
+def _render_visualisations(close_only: pd.DataFrame, selected_tickers: list[str]) -> None:
+    tabs = st.tabs(["Metrics & Prices", "Drawdowns", "Rolling Volatility"])
     with tabs[0]:
         st.markdown("#### Price history")
-        if selected_tickers:
-            price_history = (
-                close_only[selected_tickers]
-                .rename_axis("date")
-                .reset_index()
-                .melt(id_vars="date", var_name="ticker", value_name="close")
-            )
-            price_chart = (
-                alt.Chart(price_history)
-                .mark_line()
-                .encode(x="date:T", y="close:Q", color="ticker:N")
-                .properties(height=400)
-            )
-            st.altair_chart(price_chart, use_container_width=True)
-        else:
-            st.info("Select at least one ticker to display the price chart.")
-
+        _render_price_history(close_only, selected_tickers)
     with tabs[1]:
         st.markdown("#### Drawdown history")
-        if selected_tickers:
-            drawdown = close_only[selected_tickers] / close_only[selected_tickers].cummax() - 1
-            drawdown_long = (
-                drawdown.rename_axis("date")
-                .reset_index()
-                .melt(id_vars="date", var_name="ticker", value_name="drawdown")
-            )
-            drawdown_chart = (
-                alt.Chart(drawdown_long)
-                .mark_line()
-                .encode(x="date:T", y=alt.Y("drawdown:Q", title="Drawdown"), color="ticker:N")
-                .properties(height=400)
-            )
-            st.altair_chart(drawdown_chart, use_container_width=True)
-            drawdown_summary = max_drawdown(close_only[selected_tickers])
-            st.dataframe(drawdown_summary, use_container_width=True)
-        else:
-            st.info("Select at least one ticker to review drawdowns.")
-
+        _render_drawdown_history(close_only, selected_tickers)
     with tabs[2]:
         st.markdown("#### Rolling volatility")
-        if selected_tickers:
-            rolling = rolling_volatility(close_only[selected_tickers])
-            rolling_chart = (
-                alt.Chart(rolling)
-                .mark_line()
-                .encode(
-                    x="date:T",
-                    y=alt.Y("rolling_volatility:Q", title="Annualized Volatility"),
-                    color="ticker:N",
-                    strokeDash=alt.StrokeDash("window:N", title="Window"),
-                )
-                .properties(height=400)
-            )
-            st.altair_chart(rolling_chart, use_container_width=True)
-        else:
-            st.info("Select at least one ticker to inspect rolling volatility.")
+        _render_rolling_volatility(close_only, selected_tickers)
 
 
-_render()
+def _render(config: AnalysisConfig, run_requested: bool) -> None:
+    if not _ensure_analysis_requested(run_requested):
+        return
+
+    universe = _load_universe(config)
+    if universe is None:
+        return
+
+    _render_universe_section(universe)
+
+    prices = _download_prices_for(universe, config)
+    if prices.empty:
+        st.warning("Price history request returned no data for the selected options.")
+        return
+
+    sanitized = _sanitize_prices_for(prices, config, universe)
+    if not sanitized.has_close_data:
+        st.warning(
+            "All tickers were filtered out due to insufficient history or duplicate data."
+        )
+        return
+
+    _display_drop_messages(sanitized, config)
+
+    table = _compute_metric_table(config, sanitized, universe.fortune)
+    if table.empty:
+        st.warning("Metric computation returned no rows for the selected configuration.")
+        return
+
+    _render_metric_table(table, config.metric_key)
+
+    selected_tickers = _select_visualised_tickers(table, sanitized)
+
+    _render_visualisations(sanitized.close_only, selected_tickers)
+
+
+_render(config, run_analysis)


### PR DESCRIPTION
## Summary
- refactor the Streamlit app rendering pipeline around new `AnalysisConfig`/`UniverseData` helpers for clearer orchestration and reuse
- wrap `sanitize_price_matrix` results in a `SanitizedPrices` dataclass with drop-summary helpers and adjust consumers accordingly
- update and extend unit tests for the new abstractions

## Testing
- pytest tests/test_ui_helpers.py
- ruff check src/highest_volatility/app/streamlit_app.py src/highest_volatility/app/ui_helpers.py tests/test_ui_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68cd84d602b48328bfbedddba2d0bdbe