### PR TITLE
Harden API input validation and add security tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "redis",
     "streamlit",
     "pydantic-settings",
+    "httpx",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ slowapi
 redis
 streamlit
 pydantic-settings
+httpx

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security utilities for Highest Volatility services."""

--- a/src/security/validation.py
+++ b/src/security/validation.py
@@ -1,0 +1,49 @@
+"""Input validation helpers shared across security-sensitive boundaries."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+TICKER_PATTERN = re.compile(r"^[A-Z0-9.\-]{1,10}$")
+INTERVAL_PATTERN = re.compile(r"^[0-9]+[smhdw]$")
+FORMAT_CHOICES = {"json", "parquet"}
+
+
+class SanitizationError(ValueError):
+    """Raised when user supplied data fails validation."""
+
+
+def sanitize_single_ticker(ticker: str) -> str:
+    normalized = ticker.strip().upper()
+    if not normalized or not TICKER_PATTERN.fullmatch(normalized):
+        raise SanitizationError("Ticker contains invalid characters.")
+    return normalized
+
+
+def sanitize_multiple_tickers(raw: str) -> List[str]:
+    tickers = [sanitize_single_ticker(part) for part in raw.split(",") if part.strip()]
+    if not tickers:
+        raise SanitizationError("At least one ticker must be supplied.")
+    return tickers
+
+
+def sanitize_interval(interval: str) -> str:
+    normalized = interval.strip().lower()
+    if not normalized or not INTERVAL_PATTERN.fullmatch(normalized):
+        raise SanitizationError("Interval is invalid.")
+    return normalized
+
+
+def sanitize_download_format(fmt: str) -> str:
+    normalized = fmt.strip().lower()
+    if normalized not in FORMAT_CHOICES:
+        raise SanitizationError("Format is invalid.")
+    return normalized
+
+
+def sanitize_metric(metric: str) -> str:
+    normalized = metric.strip().lower()
+    if not normalized or not re.fullmatch(r"[a-z0-9_]+", normalized):
+        raise SanitizationError("Metric key contains invalid characters.")
+    return normalized

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.api import app as cache_app
+from src.highest_volatility.app.api import app as hv_app
+
+
+def test_prices_rejects_traversal() -> None:
+    with TestClient(cache_app) as client:
+        resp = client.get("/prices/AAPL", params={"interval": "../"})
+        assert resp.status_code == 400
+        assert "invalid" in resp.json()["detail"].lower()
+        for header in (
+            "strict-transport-security",
+            "x-content-type-options",
+            "x-frame-options",
+            "referrer-policy",
+        ):
+            assert header in resp.headers
+
+
+def test_metrics_rejects_header_injection() -> None:
+    with TestClient(hv_app) as client:
+        resp = client.get("/metrics", params={"tickers": "AAPL\r\nX", "metric": "cc_vol"})
+        assert resp.status_code == 400
+        for header in (
+            "strict-transport-security",
+            "x-content-type-options",
+            "x-frame-options",
+            "referrer-policy",
+        ):
+            assert header in resp.headers

--- a/tests/test_cache_store_validation.py
+++ b/tests/test_cache_store_validation.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from cache.store import save_cache
+
+
+def test_save_cache_rejects_invalid_ticker(tmp_path, monkeypatch):
+    monkeypatch.setattr("cache.store.CACHE_ROOT", tmp_path)
+    df = pd.DataFrame({"Close": [1.0]}, index=pd.date_range("2024-01-01", periods=1))
+    with pytest.raises(ValueError):
+        save_cache("BAD/TICKER", "1d", df, "test", validate=False)


### PR DESCRIPTION
## Summary
- add shared security validation helpers and wire them into both FastAPI apps and cache store
- attach security headers to API responses and tighten download filename handling
- expand tests to cover malicious input rejection and presence of security headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd93a9b6448328a1bf896e4a614dd8