### PR TITLE
Fix CLI imports to use package-relative paths

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -9,12 +9,13 @@ from datetime import date
 import pandas as pd
 
 import asyncio
-from cache.store import load_cached
-from config.interval_policy import full_backfill_start
-from datasource.yahoo import YahooDataSource
-from datasource.yahoo_async import YahooAsyncDataSource
-from ingest.fetch_async import fetch_many_async
-from ingest.async_fetch_prices import AsyncPriceFetcher
+
+from .cache.store import load_cached
+from .config.interval_policy import full_backfill_start
+from .datasource.yahoo import YahooDataSource
+from .datasource.yahoo_async import YahooAsyncDataSource
+from .ingest.fetch_async import fetch_many_async
+from .ingest.async_fetch_prices import AsyncPriceFetcher
 
 
 def _compare_frames(a: pd.DataFrame, b: pd.DataFrame) -> bool:


### PR DESCRIPTION
## Summary
- update the CLI's internal imports to use package-relative paths so that `python -m src.cli` works in the GitHub Actions environment

## Testing
- `pytest tests/test_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68cd9d6d0e6c832886ef0b8417ef41ec