### PR TITLE
Fix CLI cache import resolution

### DIFF
--- a/src/cache/store.py
+++ b/src/cache/store.py
@@ -12,7 +12,12 @@ from io import BytesIO
 
 import pandas as pd
 import requests  # type: ignore[import]
-from highest_volatility.pipeline import validate_cache
+# ``store`` is imported both as ``cache.store`` (tests/tools) and as
+# ``src.cache.store`` (production entrypoints). Importing through the
+# ``src`` package works in both scenarios because ``src`` is explicitly added
+# to ``sys.path``. This avoids ModuleNotFoundError when running ``python -m
+# src.cli`` on CI.
+from src.highest_volatility.pipeline import validate_cache
 from src.security.validation import (
     SanitizationError,
     sanitize_interval,


### PR DESCRIPTION
## Summary
- switch cache.store to import validate_cache via the src package so CLI execution resolves correctly from CI
- document the rationale inline to clarify support for both cache.store and src.cache.store import paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd9ea173108328998c02da37415bbd