### PR TITLE
Fix cache module imports for src layout

### DIFF
--- a/scripts/backfill_all_intervals.py
+++ b/scripts/backfill_all_intervals.py
@@ -39,7 +39,7 @@ def _discover_tickers() -> List[str]:
     """Discover tickers from existing cache CSVs/Parquet as a fallback."""
 
     _ensure_src_on_path()
-    from cache.store import CACHE_ROOT  # Local import to avoid lint errors
+    from src.cache.store import CACHE_ROOT  # Local import to avoid lint errors
 
     root = CACHE_ROOT
     out: set[str] = set()
@@ -57,9 +57,9 @@ def _discover_tickers() -> List[str]:
 
 async def _backfill_interval(tickers: List[str], interval: str, *, concurrency: int, throttle: float) -> None:
     _ensure_src_on_path()
-    from datasource.yahoo_http_async import YahooHTTPAsyncDataSource
-    from ingest.async_fetch_prices import AsyncPriceFetcher
-    from ingest.fetch_async import fetch_many_async
+    from src.datasource.yahoo_http_async import YahooHTTPAsyncDataSource
+    from src.ingest.async_fetch_prices import AsyncPriceFetcher
+    from src.ingest.fetch_async import fetch_many_async
 
     ds = YahooHTTPAsyncDataSource()
     fetcher = AsyncPriceFetcher(ds, source_name="yahoo-http", throttle=throttle)

--- a/scripts/repair_cache_layout.py
+++ b/scripts/repair_cache_layout.py
@@ -78,10 +78,10 @@ def _has_time_components(df: pd.DataFrame) -> bool:
 async def _refetch_30m(ticker: str, *, days: int = 60) -> pd.DataFrame:
     # Lazy import to keep script light if user only runs daily conversion
     _ensure_src_on_path()
-    from config.interval_policy import INTERVAL_WINDOWS
+    from src.config.interval_policy import INTERVAL_WINDOWS
 
     try:
-        from datasource.yahoo_http_async import YahooHTTPAsyncDataSource
+        from src.datasource.yahoo_http_async import YahooHTTPAsyncDataSource
     except Exception as exc:  # pragma: no cover
         raise RuntimeError("Missing YahooHTTPAsyncDataSource in runtime") from exc
 
@@ -99,7 +99,7 @@ async def _refetch_30m(ticker: str, *, days: int = 60) -> pd.DataFrame:
 
 def convert_legacy_daily(root: Path, *, delete_legacy: bool = False, dry_run: bool = False) -> None:
     _ensure_src_on_path()
-    from cache.store import save_cache
+    from src.cache.store import save_cache
 
     for csv in _iter_legacy_daily_csv(root):
         ticker = csv.stem
@@ -122,7 +122,7 @@ def convert_legacy_daily(root: Path, *, delete_legacy: bool = False, dry_run: bo
 
 def repair_30m(root: Path, *, refetch_days: int = 60, delete_legacy: bool = False, dry_run: bool = False) -> None:
     _ensure_src_on_path()
-    from cache.store import save_cache
+    from src.cache.store import save_cache
 
     to_fix: list[Path] = []
     for csv in _iter_legacy_30m_csv(root):
@@ -153,7 +153,7 @@ def repair_30m(root: Path, *, refetch_days: int = 60, delete_legacy: bool = Fals
     # Refetch those lacking intraday times
     async def _do_refetch():
         _ensure_src_on_path()
-        from cache.store import save_cache
+        from src.cache.store import save_cache
 
         for csv in to_fix:
             ticker = csv.stem
@@ -174,7 +174,7 @@ def repair_30m(root: Path, *, refetch_days: int = 60, delete_legacy: bool = Fals
 
 def main() -> None:
     _ensure_src_on_path()
-    from cache.store import CACHE_ROOT
+    from src.cache.store import CACHE_ROOT
 
     parser = argparse.ArgumentParser(description="Normalize cache layout and fix intraday timestamps")
     parser.add_argument("--root", type=Path, default=CACHE_ROOT, help="Cache root (default: cache/prices)")

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import Scope
 
-from cache.store import load_cached
+from src.cache.store import load_cached
 from highest_volatility.errors import CacheError, ErrorCode, HVError, wrap_error
 from highest_volatility.logging import get_logger, log_exception
 from highest_volatility.storage.ticker_cache import load_cached_fortune

--- a/src/cli.py
+++ b/src/cli.py
@@ -10,12 +10,12 @@ import pandas as pd
 
 import asyncio
 
-from .cache.store import load_cached
-from .config.interval_policy import full_backfill_start
-from .datasource.yahoo import YahooDataSource
-from .datasource.yahoo_async import YahooAsyncDataSource
-from .ingest.fetch_async import fetch_many_async
-from .ingest.async_fetch_prices import AsyncPriceFetcher
+from src.cache.store import load_cached
+from src.config.interval_policy import full_backfill_start
+from src.datasource.yahoo import YahooDataSource
+from src.datasource.yahoo_async import YahooAsyncDataSource
+from src.ingest.fetch_async import fetch_many_async
+from src.ingest.async_fetch_prices import AsyncPriceFetcher
 
 
 def _compare_frames(a: pd.DataFrame, b: pd.DataFrame) -> bool:

--- a/src/highest_volatility/ingest/prices.py
+++ b/src/highest_volatility/ingest/prices.py
@@ -16,16 +16,16 @@ import yfinance as yf
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 try:  # pragma: no cover - optional dependency
-    from datasource.yahoo_async import YahooAsyncDataSource  # type: ignore
+    from src.datasource.yahoo_async import YahooAsyncDataSource  # type: ignore
 except Exception:  # pragma: no cover - optional
     YahooAsyncDataSource = None  # type: ignore
 
-from datasource.yahoo_http_async import YahooHTTPAsyncDataSource
+from src.datasource.yahoo_http_async import YahooHTTPAsyncDataSource
 
 # Optional caching stack (present in this repo under src/cache and src/ingest)
 try:  # pragma: no cover - optional import path
-    from cache.store import load_cached, save_cache  # type: ignore
-    from cache.merge import merge_incremental  # type: ignore
+    from src.cache.store import load_cached, save_cache  # type: ignore
+    from src.cache.merge import merge_incremental  # type: ignore
 except Exception:  # pragma: no cover - optional
     load_cached = save_cache = merge_incremental = None  # type: ignore
 

--- a/src/highest_volatility/pipeline/cache_refresh.py
+++ b/src/highest_volatility/pipeline/cache_refresh.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import List
 
-from cache.store import CACHE_ROOT
+from src.cache.store import CACHE_ROOT
 from highest_volatility.ingest.prices import download_price_history
 
 

--- a/src/highest_volatility/pipeline/validation.py
+++ b/src/highest_volatility/pipeline/validation.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
-    from cache.store import Manifest
+    from src.cache.store import Manifest
 
 FREQ_MAP = {
     "1m": "1min",

--- a/src/ingest/async_fetch_prices.py
+++ b/src/ingest/async_fetch_prices.py
@@ -7,10 +7,10 @@ from typing import Optional
 import asyncio
 import pandas as pd
 
-from cache.merge import merge_incremental
-from cache.store import load_cached, save_cache
-from config.interval_policy import full_backfill_start
-from datasource.base_async import AsyncDataSource
+from src.cache.merge import merge_incremental
+from src.cache.store import load_cached, save_cache
+from src.config.interval_policy import full_backfill_start
+from src.datasource.base_async import AsyncDataSource
 from highest_volatility.errors import CacheError, DataSourceError, wrap_error
 from highest_volatility.logging import get_logger, log_exception
 

--- a/src/ingest/fetch_prices.py
+++ b/src/ingest/fetch_prices.py
@@ -8,10 +8,10 @@ from typing import Optional
 
 import pandas as pd
 
-from cache.merge import merge_incremental
-from cache.store import load_cached, save_cache
-from config.interval_policy import full_backfill_start
-from datasource.base import DataSource
+from src.cache.merge import merge_incremental
+from src.cache.store import load_cached, save_cache
+from src.config.interval_policy import full_backfill_start
+from src.datasource.base import DataSource
 
 
 class PriceFetcher:

--- a/src/pipeline/load_prices.py
+++ b/src/pipeline/load_prices.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from cache.store import load_cached
+from src.cache.store import load_cached
 
 
 def load_prices_from_cache(ticker: str, interval: str = "1d") -> pd.DataFrame:

--- a/tests/test_async_fetcher.py
+++ b/tests/test_async_fetcher.py
@@ -6,7 +6,7 @@ import aiohttp
 import pandas as pd
 import pytest
 
-from cache import store
+from src.cache import store
 from ingest.async_fetch_prices import AsyncPriceFetcher
 from ingest.fetch_async import fetch_many_async
 from datasource.base_async import AsyncDataSource

--- a/tests/test_cache_store.py
+++ b/tests/test_cache_store.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from cache import store
+from src.cache import store
 
 
 def make_df():

--- a/tests/test_cache_store_validation.py
+++ b/tests/test_cache_store_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from cache.store import save_cache
+from src.cache.store import save_cache
 
 
 def test_save_cache_rejects_invalid_ticker(tmp_path, monkeypatch):

--- a/tests/test_cache_validation.py
+++ b/tests/test_cache_validation.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from cache import store
+from src.cache import store
 from highest_volatility.pipeline import validate_cache
 
 

--- a/tests/test_merge_incremental.py
+++ b/tests/test_merge_incremental.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from cache.merge import merge_incremental
+from src.cache.merge import merge_incremental
 
 
 def test_merge_dedup_and_sort():

--- a/tests/test_price_fetcher.py
+++ b/tests/test_price_fetcher.py
@@ -3,7 +3,7 @@ from typing import List
 
 import pandas as pd
 
-from cache import store
+from src.cache import store
 from datasource.base import DataSource
 from ingest.fetch_prices import PriceFetcher
 


### PR DESCRIPTION
## Summary
- replace brittle `cache.*` imports with fully-qualified `src.cache.*` and corresponding datasource/config imports so CLI and scripts work under the src-layout
- update scripts and tests to use the new import paths, ensuring they keep forcing the repository src directory onto `sys.path`
- keep optional runtime helpers aligned so downstream packages resolve consistently

## Testing
- `pytest -q`
- `ruff check` *(fails: pre-existing unused variable warning in tests/test_additional_volatility_measures.py)*

------
https://chatgpt.com/codex/tasks/task_e_68cda2afd88483288f1bfaf6283148af