### PR TITLE
Ensure cache namespace alias resolves legacy imports

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,6 +16,7 @@ where the path is already present.
 
 from __future__ import annotations
 
+from importlib import import_module
 from pathlib import Path
 import sys
 
@@ -23,3 +24,24 @@ _SRC_ROOT = Path(__file__).resolve().parent
 _src_root_str = str(_SRC_ROOT)
 if _src_root_str not in sys.path:
     sys.path.insert(0, _src_root_str)
+
+
+def _alias_cache_modules() -> None:
+    """Expose ``cache`` modules for callers using legacy import paths."""
+
+    try:
+        cache_pkg = import_module("src.cache")
+    except ModuleNotFoundError:
+        return
+    sys.modules.setdefault("cache", cache_pkg)
+
+    for submodule in ("merge", "store"):
+        target = f"src.cache.{submodule}"
+        try:
+            module = import_module(target)
+        except ModuleNotFoundError:
+            continue
+        sys.modules.setdefault(f"cache.{submodule}", module)
+
+
+_alias_cache_modules()

--- a/src/cache/__init__.py
+++ b/src/cache/__init__.py
@@ -1,0 +1,10 @@
+"""Cache utilities bridging the ``src.cache`` and legacy ``cache`` namespaces."""
+
+from __future__ import annotations
+
+import sys
+
+_module = sys.modules[__name__]
+sys.modules.setdefault("cache", _module)
+
+__all__: list[str] = []

--- a/src/cache/merge.py
+++ b/src/cache/merge.py
@@ -20,3 +20,8 @@ def merge_incremental(existing: pd.DataFrame, new: pd.DataFrame) -> pd.DataFrame
     combined = pd.concat([existing, new])
     combined = combined[~combined.index.duplicated(keep="last")]
     return combined.sort_index()
+
+
+import sys as _sys
+
+_sys.modules.setdefault("cache.merge", _sys.modules[__name__])

--- a/src/cache/store.py
+++ b/src/cache/store.py
@@ -12,11 +12,6 @@ from io import BytesIO
 
 import pandas as pd
 import requests  # type: ignore[import]
-# ``store`` is imported both as ``cache.store`` (tests/tools) and as
-# ``src.cache.store`` (production entrypoints). Importing through the
-# ``src`` package works in both scenarios because ``src`` is explicitly added
-# to ``sys.path``. This avoids ModuleNotFoundError when running ``python -m
-# src.cli`` on CI.
 from src.highest_volatility.pipeline import validate_cache
 from src.security.validation import (
     SanitizationError,
@@ -137,3 +132,8 @@ def save_cache(
     tmp_manifest.write_text(json.dumps(asdict(manifest)))
     tmp_manifest.replace(manifest_path)
     return manifest
+
+
+import sys as _sys
+
+_sys.modules.setdefault("cache.store", _sys.modules[__name__])


### PR DESCRIPTION
## Summary
- expose the src.cache package under the legacy cache.* namespace to satisfy CLI imports
- register cache.merge and cache.store aliases during src initialisation so python -m src.cli works in CI

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cda542c45483289faf43f28f8cd9d9