### PR TITLE
Allow CLI 10m and 60m intervals

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -34,7 +34,11 @@ def _compare_frames(a: pd.DataFrame, b: pd.DataFrame) -> bool:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Price ingestion utility")
-    parser.add_argument("--interval", default="1d", choices=["1m","5m","15m","30m","1h","1d","1wk","1mo"])
+    parser.add_argument(
+        "--interval",
+        default="1d",
+        choices=["1m", "5m", "10m", "15m", "30m", "60m", "1h", "1d", "1wk", "1mo"],
+    )
     parser.add_argument("--tickers", nargs="+", required=True)
     parser.add_argument("--force-refresh", action="store_true")
     parser.add_argument("--integrity", choices=["none","sample","full"], default="none")

--- a/tests/test_src_cli_parser.py
+++ b/tests/test_src_cli_parser.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.cli import build_parser
+
+
+@pytest.mark.parametrize("interval", ["10m", "60m"])
+def test_cli_parser_accepts_new_intervals(interval):
+    parser = build_parser()
+    args = parser.parse_args(["--interval", interval, "--tickers", "AAPL"])
+    assert args.interval == interval
+
+
+def test_cli_parser_rejects_invalid_interval():
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--interval", "2m", "--tickers", "AAPL"])


### PR DESCRIPTION
## Summary
- allow the ingestion CLI to accept the 10m and 60m intervals used by automation
- add parser-focused unit tests that cover the new intervals and assert invalid intervals still fail

## Testing
- pytest tests/test_src_cli_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb237939083289be7e8d05b9b73a4