### PR TITLE
Handle business day gaps in cache validation

### DIFF
--- a/tests/test_cache_validation.py
+++ b/tests/test_cache_validation.py
@@ -29,6 +29,22 @@ def test_validate_cache_ok():
     validate_cache(df, manifest)  # should not raise
 
 
+def test_validate_cache_weekend_gap_allowed():
+    idx = pd.to_datetime(["2020-01-03", "2020-01-06"])
+    df = pd.DataFrame({"Adj Close": [1.0, 2.0]}, index=idx)
+    manifest = store.Manifest(
+        ticker="ABC",
+        interval="1d",
+        start=str(df.index[0].date()),
+        end=str(df.index[-1].date()),
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+    validate_cache(df, manifest)
+
+
 def test_validate_cache_nan():
     df = _make_df()
     df.iloc[1, 0] = None


### PR DESCRIPTION
## Summary
- make daily cache validation business-day aware so weekend spans are not treated as gaps
- reuse the business-day validator when frequency inference fails for short daily series
- cover the weekend scenario with a new cache validation unit test

## Testing
- pytest tests/test_cache_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68cdbedce3b88328b4bea74d86265e0b