### PR TITLE
Switch CLI to HTTP async datasource and add intraday coverage

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -13,7 +13,7 @@ import asyncio
 from src.cache.store import load_cached
 from src.config.interval_policy import full_backfill_start
 from src.datasource.yahoo import YahooDataSource
-from src.datasource.yahoo_async import YahooAsyncDataSource
+from src.datasource.yahoo_http_async import YahooHTTPAsyncDataSource
 from src.ingest.fetch_async import fetch_many_async
 from src.ingest.async_fetch_prices import AsyncPriceFetcher
 
@@ -51,7 +51,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    datasource = YahooAsyncDataSource()
+    datasource = YahooHTTPAsyncDataSource()
     source_name = "yahoo"
 
     fetcher = AsyncPriceFetcher(datasource, source_name=source_name, throttle=args.throttle)

--- a/tests/test_price_fetcher.py
+++ b/tests/test_price_fetcher.py
@@ -28,6 +28,17 @@ def test_incremental_and_force_refresh(tmp_path, monkeypatch):
     ds = FakeDataSource()
     fetcher = PriceFetcher(ds, throttle=0)
 
+    saved: dict[tuple[str, str], pd.DataFrame] = {}
+
+    def fake_save_cache(ticker: str, interval: str, df: pd.DataFrame, source: str) -> None:
+        saved[(ticker, interval)] = df.copy()
+
+    def fake_load_cached(ticker: str, interval: str):
+        return saved.get((ticker, interval)), None
+
+    monkeypatch.setattr("ingest.fetch_prices.save_cache", fake_save_cache)
+    monkeypatch.setattr("ingest.fetch_prices.load_cached", fake_load_cached)
+
     class D1(date):
         @classmethod
         def today(cls):


### PR DESCRIPTION
## Summary
- update the CLI wiring so `AsyncPriceFetcher` uses the `YahooHTTPAsyncDataSource`
- enhance async and sync fetcher tests with in-memory cache shims to keep incremental behaviour assertions intact
- add an integration-style async test that asserts a 60-day intraday window uses the HTTP range flow without triggering ClientResponseError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cdc2d83acc83289b3ccbfdc78fe022