### PR TITLE
Fix missing src namespace for Streamlit app

### DIFF
--- a/src/highest_volatility/__init__.py
+++ b/src/highest_volatility/__init__.py
@@ -2,4 +2,60 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+import importlib
+import sys
+from typing import Iterable
+
 __all__: list[str] = []
+
+
+def _ensure_src_namespace() -> None:
+    """Ensure the legacy ``src`` namespace is importable.
+
+    Historically this project relied on ``import src.*`` even when running
+    modules that live inside the :mod:`highest_volatility` package. When these
+    modules are executed as scripts (e.g. ``streamlit run`` on a file inside the
+    package) Python's module search path might only include the package
+    directory itself, so ``import src`` fails with ``ModuleNotFoundError``.
+
+    We attempt to import ``src`` first. If that fails we prepend the repository
+    root (two levels up from this file) to ``sys.path`` and import the package
+    from there. The helper is idempotent and safe to call multiple times.
+    """
+
+    if "src" in sys.modules:
+        return
+
+    try:
+        importlib.import_module("src")
+        return
+    except ModuleNotFoundError:
+        pass
+
+    package_root = Path(__file__).resolve().parents[2]
+    candidate = package_root / "src"
+    if not candidate.exists():
+        # Nothing we can do—bubble up the original error for visibility.
+        raise ModuleNotFoundError(
+            "The 'src' package is not available and could not be bootstrapped."
+        ) from None
+
+    root_str = str(package_root)
+    if root_str not in _sys_path_iter():
+        sys.path.insert(0, root_str)
+
+    importlib.import_module("src")
+
+
+def _sys_path_iter() -> Iterable[str]:
+    """Yield the current entries in ``sys.path``.
+
+    A tiny wrapper is provided to keep the bootstrap helper testable without
+    mutating ``sys.path`` during import-time evaluation.
+    """
+
+    return tuple(sys.path)
+
+
+_ensure_src_namespace()

--- a/tests/test_src_bootstrap.py
+++ b/tests/test_src_bootstrap.py
@@ -1,0 +1,31 @@
+"""Tests for bootstrapping the legacy ``src`` namespace."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_highest_volatility_bootstraps_src(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
+    """Importing :mod:`highest_volatility` makes ``src`` available."""
+
+    cleaned = [
+        entry for entry in sys.path if Path(entry).resolve() != repo_root
+    ]
+    monkeypatch.setattr(sys, "path", cleaned, raising=False)
+    monkeypatch.delitem(sys.modules, "highest_volatility", raising=False)
+    monkeypatch.delitem(sys.modules, "src", raising=False)
+
+    module = importlib.import_module("highest_volatility")
+
+    assert "src" in sys.modules
+    assert any(Path(entry).resolve() == repo_root for entry in sys.path)
+    assert module is sys.modules["highest_volatility"]


### PR DESCRIPTION
## Summary
- ensure importing `highest_volatility` bootstraps the legacy `src` namespace when it is absent from `sys.path`
- cover the bootstrap behaviour with a regression test so the Streamlit app can import CLI helpers without ModuleNotFoundError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce04b64aa88328a266d10ec918cd1a