### PR TITLE
Enhance fallback NYSE calendar with special closures

### DIFF
--- a/src/highest_volatility/pipeline/validation.py
+++ b/src/highest_volatility/pipeline/validation.py
@@ -24,7 +24,11 @@ from pandas.tseries.holiday import (
 
 
 class _FallbackNYSEHolidayCalendar(AbstractHolidayCalendar):
-    """Approximation of NYSE full-day holidays when ``pandas-market-calendars`` is unavailable."""
+    """Approximation of NYSE full-day holidays when ``pandas-market-calendars`` is unavailable.
+
+    The special-closure dates mirror historical NYSE shutdowns documented at
+    https://www.nyse.com/markets/hours-calendars/historical-holidays.
+    """
 
     rules = [
         Holiday("NewYearsDay", month=1, day=1, observance=nearest_workday),
@@ -43,6 +47,18 @@ class _FallbackNYSEHolidayCalendar(AbstractHolidayCalendar):
         USLaborDay,
         USThanksgivingDay,
         Holiday("ChristmasDay", month=12, day=25, observance=nearest_workday),
+        # One-off full-day closures observed by the NYSE since the mid-1980s.
+        Holiday("NYSESpecialClosure1985Sep27", year=1985, month=9, day=27),
+        Holiday("NYSESpecialClosure1994Apr27", year=1994, month=4, day=27),
+        Holiday("NYSESpecialClosure2001Sep11", year=2001, month=9, day=11),
+        Holiday("NYSESpecialClosure2001Sep12", year=2001, month=9, day=12),
+        Holiday("NYSESpecialClosure2001Sep13", year=2001, month=9, day=13),
+        Holiday("NYSESpecialClosure2001Sep14", year=2001, month=9, day=14),
+        Holiday("NYSESpecialClosure2004Jun11", year=2004, month=6, day=11),
+        Holiday("NYSESpecialClosure2007Jan02", year=2007, month=1, day=2),
+        Holiday("NYSESpecialClosure2012Oct29", year=2012, month=10, day=29),
+        Holiday("NYSESpecialClosure2012Oct30", year=2012, month=10, day=30),
+        Holiday("NYSESpecialClosure2018Dec05", year=2018, month=12, day=5),
     ]
 
 

--- a/tests/test_cache_validation.py
+++ b/tests/test_cache_validation.py
@@ -87,6 +87,41 @@ def test_validate_cache_holiday_gap_allowed_without_mcal(monkeypatch):
         validation._get_trading_calendar.cache_clear()
 
 
+@pytest.mark.parametrize(
+    "start_date,end_date",
+    [
+        ("1985-09-26", "1985-09-30"),
+        ("1994-04-26", "1994-04-28"),
+        ("2001-09-10", "2001-09-17"),
+        ("2004-06-10", "2004-06-14"),
+        ("2006-12-29", "2007-01-03"),
+        ("2012-10-26", "2012-10-31"),
+        ("2018-12-04", "2018-12-06"),
+    ],
+)
+def test_validate_cache_special_closures_without_mcal(monkeypatch, start_date, end_date):
+    monkeypatch.setattr(validation, "mcal", None)
+    validation._get_trading_calendar.cache_clear()
+
+    idx = pd.to_datetime([start_date, end_date])
+    df = pd.DataFrame({"Adj Close": [1.0, 2.0]}, index=idx)
+    manifest = store.Manifest(
+        ticker="ABC",
+        interval="1d",
+        start=str(df.index[0].date()),
+        end=str(df.index[-1].date()),
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+
+    try:
+        validate_cache(df, manifest)
+    finally:
+        validation._get_trading_calendar.cache_clear()
+
+
 def test_validate_cache_nan():
     df = _make_df()
     df.iloc[1, 0] = None


### PR DESCRIPTION
## Summary
- extend the fallback NYSE calendar with one-off closures dating back to the mid-1980s and document the historical source
- add regression coverage ensuring manifests spanning these shutdowns do not report gaps when pandas-market-calendars is unavailable

## Testing
- pytest tests/test_cache_validation.py
- ruff check src/highest_volatility/pipeline/validation.py tests/test_cache_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68ceb49950b883289583c571fd12a5f0