### PR TITLE
Relax intraday cache validation

### DIFF
--- a/tests/test_cache_validation.py
+++ b/tests/test_cache_validation.py
@@ -147,6 +147,45 @@ def test_validate_cache_gap():
         validate_cache(df, manifest)
 
 
+def test_validate_cache_intraday_extended_hours_gap_allowed():
+    validation._get_trading_calendar.cache_clear()
+
+    idx = pd.to_datetime(["2024-01-02 16:00", "2024-01-02 16:05"])
+    df = pd.DataFrame({"Adj Close": [1.0, 2.0]}, index=idx)
+    manifest = store.Manifest(
+        ticker="ABC",
+        interval="1m",
+        start=str(df.index[0].date()),
+        end=str(df.index[-1].date()),
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+
+    validate_cache(df, manifest)
+
+
+def test_validate_cache_intraday_regular_hours_gap_detected():
+    validation._get_trading_calendar.cache_clear()
+
+    idx = pd.to_datetime(["2024-01-02 09:30", "2024-01-02 09:32"])
+    df = pd.DataFrame({"Adj Close": [1.0, 2.0]}, index=idx)
+    manifest = store.Manifest(
+        ticker="ABC",
+        interval="1m",
+        start=str(df.index[0].date()),
+        end=str(df.index[-1].date()),
+        rows=len(df),
+        source="test",
+        version=1,
+        updated_at="2020-01-01T00:00:00Z",
+    )
+
+    with pytest.raises(ValueError):
+        validate_cache(df, manifest)
+
+
 def test_validate_cache_gap_detected_without_mcal(monkeypatch):
     monkeypatch.setattr(validation, "mcal", None)
     validation._get_trading_calendar.cache_clear()


### PR DESCRIPTION
## Summary
- add intraday-aware validation helpers that ignore extended-hours gaps while enforcing regular session continuity
- update `validate_cache` to use the intraday helpers when minute/hour data is validated
- extend cache validation tests to cover extended-hours allowances and regular-session gap detection

## Testing
- pytest tests/test_cache_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68ceb567d868832899984b17bf56cb16