### PR TITLE
Use interval policy for initial cache fetch

### DIFF
--- a/tests/test_prices_async.py
+++ b/tests/test_prices_async.py
@@ -5,8 +5,12 @@ from datetime import date, datetime
 
 
 class FakeAsyncDS:
+    def __init__(self):
+        self.calls: list[tuple[str, date, date, str]] = []
+
     async def get_prices(self, ticker, start, end, interval):
-        idx = pd.date_range("2020-01-01", periods=3)
+        self.calls.append((ticker, start, end, interval))
+        idx = pd.date_range(start, periods=3)
         return pd.DataFrame({"Adj Close": [1, 2, 3]}, index=idx)
 
 
@@ -21,11 +25,20 @@ def test_download_price_history_async(monkeypatch):
         def utcnow(cls):
             return datetime(2020, 1, 6)
 
+    fake_ds = FakeAsyncDS()
+
+    def fake_full_backfill(interval, today=None):
+        assert interval == "1d"
+        assert today == date(2020, 1, 6)
+        return date(2019, 12, 30)
+
     monkeypatch.setattr(prices, "date", D)
     monkeypatch.setattr(prices, "datetime", DT)
-    monkeypatch.setattr(prices, "YahooAsyncDataSource", lambda: FakeAsyncDS())
+    monkeypatch.setattr(prices, "full_backfill_start", fake_full_backfill)
+    monkeypatch.setattr(prices, "YahooAsyncDataSource", lambda: fake_ds)
 
     df = prices.download_price_history(["AAA", "BBB"], 5, matrix_mode="async", use_cache=False)
     assert set(df.columns.get_level_values(1)) == {"AAA", "BBB"}
     assert "Adj Close" in df.columns.get_level_values(0)
+    assert all(call[1] == date(2019, 12, 30) for call in fake_ds.calls)
 

--- a/tests/test_prices_cache_policy.py
+++ b/tests/test_prices_cache_policy.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+import pandas as pd
+
+from highest_volatility.ingest import prices
+
+
+def _setup_time(monkeypatch, today: date) -> None:
+    class _Date(date):
+        @classmethod
+        def today(cls) -> date:  # type: ignore[override]
+            return today
+
+    class _DateTime(datetime):
+        @classmethod
+        def utcnow(cls) -> datetime:  # type: ignore[override]
+            return datetime.combine(today, datetime.min.time())
+
+    monkeypatch.setattr(prices, "date", _Date)
+    monkeypatch.setattr(prices, "datetime", _DateTime)
+
+
+def _install_cache_stubs(
+    monkeypatch, expected_start: date, interval: str, freq: str
+) -> tuple[list[Any], dict[tuple[str, str], pd.DataFrame], list[tuple[str, date | None]]]:
+    starts: list[Any] = []
+    saved: dict[tuple[str, str], pd.DataFrame] = {}
+    full_backfill_calls: list[tuple[str, date | None]] = []
+
+    def fake_full_backfill_start(interval_arg: str, today: date | None = None) -> date:
+        assert interval_arg == interval
+        assert today is not None
+        full_backfill_calls.append((interval_arg, today))
+        return expected_start
+
+    def fake_load_cached(ticker: str, interval_arg: str) -> tuple[pd.DataFrame | None, Any]:
+        assert interval_arg == interval
+        return None, None
+
+    def fake_save_cache(ticker: str, interval_arg: str, df: pd.DataFrame, source: str, **_: Any) -> None:
+        assert interval_arg == interval
+        saved[(ticker, interval_arg)] = df.copy()
+
+    def fake_download(*_, **kwargs: Any) -> pd.DataFrame:
+        starts.append(kwargs["start"])
+        idx = pd.date_range(kwargs["start"], periods=3, freq=freq)
+        return pd.DataFrame({"Adj Close": range(len(idx))}, index=idx)
+
+    monkeypatch.setattr(prices, "full_backfill_start", fake_full_backfill_start)
+    monkeypatch.setattr(prices, "load_cached", fake_load_cached)
+    monkeypatch.setattr(prices, "save_cache", fake_save_cache)
+    monkeypatch.setattr(prices.yf, "download", fake_download)
+
+    return starts, saved, full_backfill_calls
+
+
+def test_first_run_cache_uses_full_backfill_daily(monkeypatch):
+    today = date(2020, 1, 10)
+    _setup_time(monkeypatch, today)
+    expected_start = date(2020, 1, 1)
+    starts, saved, calls = _install_cache_stubs(monkeypatch, expected_start, "1d", "D")
+
+    df = prices.download_price_history(["AAA"], 5, matrix_mode="cache", use_cache=True, max_workers=1)
+
+    assert calls == [("1d", today)]
+    assert [pd.Timestamp(s).date() for s in starts] == [expected_start]
+    cached = saved[("AAA", "1d")]
+    assert cached.index.min().date() == expected_start
+    # Returned frame is trimmed to lookback window but should still include data
+    assert not df.empty
+
+
+def test_first_run_cache_uses_full_backfill_intraday(monkeypatch):
+    today = date(2020, 1, 10)
+    _setup_time(monkeypatch, today)
+    expected_start = date(2020, 1, 9)
+    starts, saved, calls = _install_cache_stubs(monkeypatch, expected_start, "1m", "min")
+
+    df = prices.download_price_history(
+        ["AAA"],
+        5,
+        matrix_mode="cache",
+        use_cache=True,
+        max_workers=1,
+        prepost=True,
+        interval="1m",
+    )
+
+    assert calls == [("1m", today)]
+    assert [pd.Timestamp(s).date() for s in starts] == [expected_start]
+    cached = saved[("AAA", "1m")]
+    assert cached.index.min().date() == expected_start
+    assert not df.empty


### PR DESCRIPTION
## Summary
- derive cache backfill start dates from the interval policy for sync and async price downloads
- add regression tests that confirm first-run cache fetches span the configured backfill windows for daily and intraday intervals
- ensure the async downloader passes the policy-derived start date to the async data source

## Testing
- pytest tests/test_prices_async.py tests/test_prices_cache_policy.py

------
https://chatgpt.com/codex/tasks/task_e_68cee0f2b35c8328953dfea741249b92