### PR TITLE
Allow extended interval suffixes

### DIFF
--- a/src/security/validation.py
+++ b/src/security/validation.py
@@ -8,7 +8,7 @@ from typing import List
 from highest_volatility.errors import ValidationError
 
 TICKER_PATTERN = re.compile(r"^[A-Z0-9.\-]{1,10}$")
-INTERVAL_PATTERN = re.compile(r"^[0-9]+[smhdw]$")
+INTERVAL_PATTERN = re.compile(r"^[0-9]+(?:wk|mo|[smhdw])$")
 FORMAT_CHOICES = {"json", "parquet"}
 
 

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -1,0 +1,27 @@
+"""Tests for security validation helpers."""
+
+import pytest
+
+from src.security.validation import SanitizationError, sanitize_interval
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("5wk", "5wk"),
+        ("3WK", "3wk"),
+        ("2mo", "2mo"),
+    ],
+)
+def test_sanitize_interval_accepts_extended_suffixes(raw: str, expected: str) -> None:
+    """Intervals with supported suffixes should be normalized."""
+
+    assert sanitize_interval(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["10yr", "15", "7 weeks"])
+def test_sanitize_interval_rejects_invalid_suffixes(raw: str) -> None:
+    """Unsupported interval suffixes must raise a sanitization error."""
+
+    with pytest.raises(SanitizationError):
+        sanitize_interval(raw)


### PR DESCRIPTION
## Summary
- allow intervals sanitized by security validation to accept `wk` and `mo` suffixes
- add unit tests covering success and failure cases for the new interval handling

## Testing
- pytest tests/test_security_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68cf0696f8a08328be0ca2d93f9a768a