### PR TITLE
Update CLI interval choices to favor 1h

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -37,7 +37,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--interval",
         default="1d",
-        choices=["1m", "5m", "10m", "15m", "30m", "60m", "1h", "1d", "1wk", "1mo"],
+        choices=["1m", "5m", "15m", "30m", "1h", "1d", "1wk", "1mo"],
     )
     parser.add_argument("--tickers", nargs="+", required=True)
     parser.add_argument("--force-refresh", action="store_true")

--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -20,7 +20,7 @@ DEFAULT_LOOKBACK_DAYS = 252
 DEFAULT_TOP_N = 100
 DEFAULT_PRINT_TOP = 5
 DEFAULT_MIN_DAYS = 126
-INTERVAL_CHOICES = ["1d", "60m", "30m", "15m", "5m", "1m"]
+INTERVAL_CHOICES = ["1d", "1h", "30m", "15m", "5m", "1m"]
 # Load any third-party metric plugins before building choices
 load_plugins()
 METRIC_CHOICES = sorted(METRIC_REGISTRY.keys())

--- a/tests/test_src_cli_parser.py
+++ b/tests/test_src_cli_parser.py
@@ -3,8 +3,8 @@ import pytest
 from src.cli import build_parser
 
 
-@pytest.mark.parametrize("interval", ["10m", "60m"])
-def test_cli_parser_accepts_new_intervals(interval):
+@pytest.mark.parametrize("interval", ["1h"])
+def test_cli_parser_accepts_new_interval(interval):
     parser = build_parser()
     args = parser.parse_args(["--interval", interval, "--tickers", "AAPL"])
     assert args.interval == interval
@@ -14,3 +14,10 @@ def test_cli_parser_rejects_invalid_interval():
     parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["--interval", "2m", "--tickers", "AAPL"])
+
+
+@pytest.mark.parametrize("interval", ["10m", "60m"])
+def test_cli_parser_rejects_removed_intervals(interval):
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--interval", interval, "--tickers", "AAPL"])


### PR DESCRIPTION
## Summary
- update both CLI entry points to drop 10m/60m interval options in favor of the canonical 1h value
- refresh CLI parser tests to cover 1h acceptance and ensure the removed intervals now raise errors

## Testing
- pytest tests/test_src_cli_parser.py
- pytest tests/test_async_fetcher.py tests/test_prices_async.py

------
https://chatgpt.com/codex/tasks/task_e_68cf07f8d4bc83288154db548265b9a8