### PR TITLE
Enable concurrent chunk downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ same trading day are merged correctly. The synchronous and asynchronous
 fetchers share this behavior, with ``tests/test_price_fetcher.py`` verifying the
 intraday cache replay alongside the existing daily interval regression.
 
+### Batch Price Downloads
+
+The synchronous ``download_price_history`` helper downloads tickers in chunks of
+40 symbols. Each chunk is submitted to a thread pool so multiple batches can be
+in-flight when ``max_workers`` is greater than one. A failed chunk will fall
+back to sequential single-ticker retries inside its worker without blocking
+other threads. Tune ``max_workers`` based on available CPU capacity and the
+latency of your network connection; values between 4 and 8 work well for most
+desktop environments. Introduce a short ``chunk_sleep`` (for example, ``0.5``
+seconds) after each batch if the upstream API begins throttling requests.
+
 Client utilities such as ``cache.store`` will hydrate missing local cache files
 from this API when the ``HV_API_BASE_URL`` environment variable is set.
 

--- a/tests/test_prices_batch_concurrency.py
+++ b/tests/test_prices_batch_concurrency.py
@@ -1,0 +1,95 @@
+import time
+from concurrent.futures import Future
+from typing import List
+from unittest.mock import patch
+
+import pandas as pd
+
+from src.highest_volatility.ingest import prices
+
+
+def _make_chunk_frame(tickers: List[str]) -> pd.DataFrame:
+    idx = pd.date_range(end=pd.Timestamp.now(tz=None), periods=1, freq="D")
+    if len(tickers) == 1:
+        return pd.DataFrame({"Adj Close": [1.0]}, index=idx)
+    columns = pd.MultiIndex.from_product([["Adj Close"], tickers])
+    data = [list(range(1, len(tickers) + 1))]
+    return pd.DataFrame(data, index=idx, columns=columns)
+
+
+def test_batch_download_submits_multiple_chunks():
+    tickers = [f"T{i}" for i in range(80)]
+    submissions: List[List[str]] = []
+    worker_counts: List[int] = []
+
+    def fake_download(tickers_arg, *args, **kwargs):
+        symbols = tickers_arg.split(" ") if isinstance(tickers_arg, str) else list(tickers_arg)
+        return _make_chunk_frame(symbols)
+
+    class ImmediateExecutor:
+        def __init__(self, max_workers: int):
+            worker_counts.append(max_workers)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            submissions.append(list(args[1]))
+            future: Future = Future()
+            future.set_result(fn(*args, **kwargs))
+            return future
+
+    with patch(
+        "src.highest_volatility.ingest.prices.ThreadPoolExecutor",
+        side_effect=lambda max_workers: ImmediateExecutor(max_workers),
+    ):
+        with patch("src.highest_volatility.ingest.prices.yf.download", side_effect=fake_download):
+            df = prices.download_price_history(
+                tickers,
+                lookback_days=5,
+                matrix_mode="batch",
+                use_cache=False,
+                max_workers=4,
+            )
+
+    assert not df.empty
+    assert submissions == [tickers[:40], tickers[40:]]
+    # The executor is sized to the batch of pending chunks (two workers for the first batch).
+    assert worker_counts == [2]
+
+
+def test_concurrent_batches_reduce_latency():
+    tickers = [f"S{i}" for i in range(80)]
+    sleep_seconds = 0.2
+
+    def sleepy_download(tickers_arg, *args, **kwargs):
+        time.sleep(sleep_seconds)
+        symbols = tickers_arg.split(" ") if isinstance(tickers_arg, str) else list(tickers_arg)
+        return _make_chunk_frame(symbols)
+
+    with patch("src.highest_volatility.ingest.prices.yf.download", side_effect=sleepy_download):
+        start_serial = time.perf_counter()
+        prices.download_price_history(
+            tickers,
+            lookback_days=5,
+            matrix_mode="batch",
+            use_cache=False,
+            max_workers=1,
+        )
+        serial_duration = time.perf_counter() - start_serial
+
+    with patch("src.highest_volatility.ingest.prices.yf.download", side_effect=sleepy_download):
+        start_concurrent = time.perf_counter()
+        prices.download_price_history(
+            tickers,
+            lookback_days=5,
+            matrix_mode="batch",
+            use_cache=False,
+            max_workers=4,
+        )
+        concurrent_duration = time.perf_counter() - start_concurrent
+
+    assert concurrent_duration < serial_duration * 0.75


### PR DESCRIPTION
## Summary
- execute batch price downloads concurrently by honoring the max_workers thread pool limit and keeping deterministic stitching
- preserve sequential single-ticker fallbacks per chunk while allowing other batches to proceed and add throttling between concurrent batches
- document the new concurrency behaviour and cover it with tests, including a latency benchmark that exercises the threaded downloader

## Testing
- pytest tests/test_prices_batch_concurrency.py

------
https://chatgpt.com/codex/tasks/task_e_68cfff363a8483288a2eddbe6837aa3e