### PR TITLE
Refactor CLI workflow into testable steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ selected with the ``--metric`` option:
 - ``var`` – value at risk (VaR)
 - ``sortino`` – annualised Sortino ratio
 
+## CLI Internals & Rollback Plan
+
+The CLI now orchestrates four focused steps – universe construction, price
+downloads (with sanitisation via ``highest_volatility.app.sanitization``),
+metric computation, and result rendering. Each step returns a small data class
+so the workflow can be unit tested in isolation and downstream tooling can
+reuse the intermediate structures.
+
+To roll back to the previous monolithic ``main`` implementation, restore
+``src/highest_volatility/app/cli.py`` from the last release tag or a specific
+commit and remove ``src/highest_volatility/app/sanitization.py``. For example,
+``git checkout <prior-tag> -- src/highest_volatility/app/cli.py`` followed by
+``git rm src/highest_volatility/app/sanitization.py`` reverts the refactor
+while keeping the rest of the repository unchanged.
+
 ## Streamlit App
 
 An interactive dashboard is available via Streamlit. It mirrors the CLI

--- a/src/highest_volatility/app/cli.py
+++ b/src/highest_volatility/app/cli.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import argparse
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
-import time
 
 import pandas as pd
 
+from highest_volatility.app.sanitization import sanitize_close
 from highest_volatility.compute.metrics import METRIC_REGISTRY, load_plugins
 from highest_volatility.ingest.prices import download_price_history
-from highest_volatility.universe import build_universe
 from highest_volatility.storage.csv_store import save_csv
 from highest_volatility.storage.sqlite_store import save_sqlite
+from highest_volatility.universe import build_universe
 
 
 DEFAULT_LOOKBACK_DAYS = 252
@@ -135,30 +137,72 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: Optional[List[str]] = None) -> None:
-    """Entry point for the CLI."""
+@dataclass(frozen=True)
+class BuildUniverseResult:
+    """Container describing the outcome of the universe build step."""
 
-    args = parse_args(argv)
+    tickers: list[str]
+    fortune: pd.DataFrame
+    duration: float
 
-    timings: dict[str, float] = {}
 
-    print("[1/4] Building universe (Selenium)…", flush=True)
-    t0 = time.perf_counter()
+@dataclass(frozen=True)
+class DownloadPricesResult:
+    """Container describing the outcome of the price download step."""
+
+    prices: pd.DataFrame
+    close: pd.DataFrame
+    tickers: list[str]
+    dropped_short: list[str]
+    dropped_duplicate: list[str]
+    duration: float
+
+
+@dataclass(frozen=True)
+class ComputeMetricsResult:
+    """Container describing the computed metrics output."""
+
+    result: pd.DataFrame
+    duration: float
+
+
+@dataclass(frozen=True)
+class RenderOutputResult:
+    """Container describing the rendering/exporting step."""
+
+    duration: float
+
+
+def _extract_close(prices: pd.DataFrame) -> pd.DataFrame:
+    """Extract the close or adjusted close slice from raw prices."""
+
+    if isinstance(prices.columns, pd.MultiIndex):
+        if "Adj Close" in prices.columns.get_level_values(0):
+            return prices["Adj Close"]
+        return prices["Close"]
+    return prices["Adj Close"] if "Adj Close" in prices.columns else prices["Close"]
+
+
+def _build_universe_step(args: argparse.Namespace) -> BuildUniverseResult:
+    """Retrieve the Fortune universe and measure execution time."""
+
+    start = time.perf_counter()
     tickers, fortune = build_universe(
         args.top_n,
         validate=args.validate_universe,
         use_ticker_cache=not args.refresh_tickers,
         ticker_cache_days=args.tickers_cache_days,
     )
-    timings["build_universe"] = time.perf_counter() - t0
-    print(f"      Universe size: {len(tickers)} tickers", flush=True)
-    if len(tickers) < args.print_top:
-        raise SystemExit(
-            f"Universe too small: got {len(tickers)} tickers, but --print-top={args.print_top}. "
-            "Check pagination / fetch source."
-        )
-    print("[2/4] Downloading price history…", flush=True)
-    t0 = time.perf_counter()
+    duration = time.perf_counter() - start
+    return BuildUniverseResult(tickers=tickers, fortune=fortune, duration=duration)
+
+
+def _download_prices_step(
+    args: argparse.Namespace, tickers: list[str]
+) -> DownloadPricesResult:
+    """Download and sanitize price history for the provided tickers."""
+
+    start = time.perf_counter()
     prices = download_price_history(
         tickers,
         args.lookback_days,
@@ -170,68 +214,41 @@ def main(argv: Optional[List[str]] = None) -> None:
         matrix_mode="async" if args.async_fetch else "batch",
         max_retries=args.max_retries,
     )
-    timings["download_prices"] = time.perf_counter() - t0
+    duration = time.perf_counter() - start
+    close = _extract_close(prices)
+    close, dropped_short, dropped_dupe = sanitize_close(close, args.min_days)
+
+    # Align raw prices to sanitized tickers for downstream metrics
+    keep_tickers = list(close.columns)
     if isinstance(prices.columns, pd.MultiIndex):
-        if "Adj Close" in prices.columns.get_level_values(0):
-            close = prices["Adj Close"]
-        else:
-            close = prices["Close"]
+        prices = prices.loc[:, prices.columns.get_level_values(1).isin(keep_tickers)]
     else:
-        close = (
-            prices["Adj Close"] if "Adj Close" in prices.columns else prices["Close"]
-        )
+        prices = prices.loc[:, keep_tickers]
 
-    # Sanitize price matrix to prevent duplicate/degenerate series from skewing metrics
-    def _sanitize_close(df: pd.DataFrame, min_days: int) -> tuple[pd.DataFrame, list[str], list[str]]:
-        import hashlib
-        dropped_short: list[str] = []
-        dropped_dupe: list[str] = []
-        # Drop duplicate-named columns to avoid ambiguous selections
-        df = df.loc[:, ~df.columns.duplicated(keep="first")]
-        # Drop columns with insufficient data (count non-NaN strictly per column)
-        keep_cols: list[str] = []
-        for c in df.columns:
-            if int(df[c].notna().sum()) >= min_days:
-                keep_cols.append(c)
-            else:
-                dropped_short.append(c)
-        df2 = df[keep_cols].copy()
-        # Drop exact-duplicate recent tails
-        seen: dict[str, str] = {}
-        tail_n = min(250, max(60, min_days))
-        for c in list(df2.columns):
-            s = df2[c].tail(tail_n).astype(float).ffill().bfill()
-            if s.dropna().empty:
-                df2 = df2.drop(columns=[c])
-                continue
-            sig = hashlib.sha1(s.to_numpy().tobytes()).hexdigest()
-            if sig in seen:
-                dropped_dupe.append(c)
-                df2 = df2.drop(columns=[c])
-            else:
-                seen[sig] = c
-        return df2, dropped_short, dropped_dupe
+    sanitized_tickers = [ticker for ticker in tickers if ticker in keep_tickers]
+    return DownloadPricesResult(
+        prices=prices,
+        close=close,
+        tickers=sanitized_tickers,
+        dropped_short=dropped_short,
+        dropped_duplicate=dropped_dupe,
+        duration=duration,
+    )
 
-    close, dropped_short, dropped_dupe = _sanitize_close(close, args.min_days)
-    if dropped_short or dropped_dupe:
-        print(
-            f"      Sanitized price matrix: dropped {len(dropped_short)} short and {len(dropped_dupe)} duplicate series",
-            flush=True,
-        )
-    # Filter raw prices (OHLC) to the remaining tickers for downstream metrics
-    if isinstance(prices.columns, pd.MultiIndex):
-        # Keep only tickers present after sanitization
-        keep = [c for c in close.columns]
-        prices = prices.loc[:, prices.columns.get_level_values(1).isin(keep)]
-        # Ensure expected order isn't required later
-    tickers = [t for t in tickers if t in close.columns]
-    print("[3/4] Computing metrics…", flush=True)
-    t0 = time.perf_counter()
+
+def _compute_metrics_step(
+    args: argparse.Namespace,
+    prices_result: DownloadPricesResult,
+    fortune: pd.DataFrame,
+) -> ComputeMetricsResult:
+    """Compute the ranking metrics for the sanitized universe."""
+
+    start = time.perf_counter()
     metric_func = METRIC_REGISTRY[args.metric]
     metric_df = metric_func(
-        prices,
-        tickers=tickers,
-        close=close,
+        prices_result.prices,
+        tickers=prices_result.tickers,
+        close=prices_result.close,
         min_periods=args.min_days,
         interval=args.interval,
     )
@@ -243,24 +260,74 @@ def main(argv: Optional[List[str]] = None) -> None:
         fortune.set_index("ticker")["rank"]
     )
     result = result[~result.index.duplicated(keep="first")]
-    timings["compute_metrics"] = time.perf_counter() - t0
+    duration = time.perf_counter() - start
+    return ComputeMetricsResult(result=result, duration=duration)
 
-    print(f"[4/4] Top {args.print_top} rows:")
-    t0 = time.perf_counter()
-    # Reorder columns to show identifiers first
+
+def _render_output_step(
+    args: argparse.Namespace, compute_result: ComputeMetricsResult
+) -> RenderOutputResult:
+    """Render CLI output and optional exports, capturing execution time."""
+
+    start = time.perf_counter()
+    result = compute_result.result.copy()
     if "company" in result.columns and "rank" in result.columns:
         id_cols = ["rank", "company"]
-        metric_cols = [c for c in result.columns if c not in id_cols]
+        metric_cols = [col for col in result.columns if col not in id_cols]
         result = result[id_cols + metric_cols]
+
     print(result.head(args.print_top).to_string())
-    timings["print_top"] = time.perf_counter() - t0
+
+    if args.output_csv:
+        save_csv(result.reset_index(), args.output_csv)
+    if args.output_sqlite:
+        save_sqlite(result.reset_index(), args.output_sqlite)
+
+    duration = time.perf_counter() - start
+    return RenderOutputResult(duration=duration)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Entry point for the CLI."""
+
+    args = parse_args(argv)
+    timings: dict[str, float] = {}
+
+    print("[1/4] Building universe (Selenium)…", flush=True)
+    universe_result = _build_universe_step(args)
+    timings["build_universe"] = universe_result.duration
+    print(f"      Universe size: {len(universe_result.tickers)} tickers", flush=True)
+    if len(universe_result.tickers) < args.print_top:
+        raise SystemExit(
+            f"Universe too small: got {len(universe_result.tickers)} tickers, but --print-top={args.print_top}. "
+            "Check pagination / fetch source."
+        )
+
+    print("[2/4] Downloading price history…", flush=True)
+    prices_result = _download_prices_step(args, universe_result.tickers)
+    timings["download_prices"] = prices_result.duration
+    if prices_result.dropped_short or prices_result.dropped_duplicate:
+        print(
+            "      Sanitized price matrix: "
+            f"dropped {len(prices_result.dropped_short)} short and "
+            f"{len(prices_result.dropped_duplicate)} duplicate series",
+            flush=True,
+        )
+
+    print("[3/4] Computing metrics…", flush=True)
+    compute_result = _compute_metrics_step(args, prices_result, universe_result.fortune)
+    timings["compute_metrics"] = compute_result.duration
+
+    print(f"[4/4] Top {args.print_top} rows:")
+    render_result = _render_output_step(args, compute_result)
+    timings["print_top"] = render_result.duration
 
     if args.timings:
-        # Summarize timings
-        def fmt(x: float) -> str:
-            return f"{x:.2f}s"
-
         total = sum(timings.values())
+
+        def fmt(value: float) -> str:
+            return f"{value:.2f}s"
+
         print(
             "\nTimings: "
             f"build_universe={fmt(timings.get('build_universe', 0.0))}, "
@@ -269,8 +336,3 @@ def main(argv: Optional[List[str]] = None) -> None:
             f"print_top={fmt(timings.get('print_top', 0.0))}, "
             f"total={fmt(total)}"
         )
-
-    if args.output_csv:
-        save_csv(result.reset_index(), args.output_csv)
-    if args.output_sqlite:
-        save_sqlite(result.reset_index(), args.output_sqlite)

--- a/src/highest_volatility/app/sanitization.py
+++ b/src/highest_volatility/app/sanitization.py
@@ -1,0 +1,61 @@
+"""Helpers for cleaning price matrices prior to metric computation."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pandas as pd
+
+
+def sanitize_close(
+    close: pd.DataFrame, min_days: int
+) -> Tuple[pd.DataFrame, List[str], List[str]]:
+    """Drop incomplete or duplicate price series from a close-price matrix.
+
+    Parameters
+    ----------
+    close:
+        DataFrame of close or adjusted close prices keyed by ticker.
+    min_days:
+        Minimum number of non-null observations required per ticker.
+
+    Returns
+    -------
+    tuple
+        ``(clean_close, dropped_short, dropped_duplicate)`` where ``clean_close``
+        retains valid tickers only, ``dropped_short`` lists tickers removed for
+        insufficient history, and ``dropped_duplicate`` lists those removed as
+        duplicate series (matching recent tails).
+    """
+
+    import hashlib
+
+    dropped_short: List[str] = []
+    dropped_dupe: List[str] = []
+
+    clean = close.loc[:, ~close.columns.duplicated(keep="first")]
+
+    keep_columns: List[str] = []
+    for column in clean.columns:
+        if int(clean[column].notna().sum()) >= min_days:
+            keep_columns.append(column)
+        else:
+            dropped_short.append(column)
+
+    clean = clean[keep_columns].copy()
+
+    seen: dict[str, str] = {}
+    tail_n = min(250, max(60, min_days))
+    for column in list(clean.columns):
+        series = clean[column].tail(tail_n).astype(float).ffill().bfill()
+        if series.dropna().empty:
+            clean = clean.drop(columns=[column])
+            continue
+        signature = hashlib.sha1(series.to_numpy().tobytes()).hexdigest()
+        if signature in seen:
+            dropped_dupe.append(column)
+            clean = clean.drop(columns=[column])
+        else:
+            seen[signature] = column
+
+    return clean, dropped_short, dropped_dupe

--- a/tests/test_cli_guard.py
+++ b/tests/test_cli_guard.py
@@ -21,3 +21,44 @@ def test_cli_fails_if_universe_too_small(monkeypatch):
 
     with pytest.raises(SystemExit, match="Universe too small"):
         cli.main(["--top-n", "2", "--print-top", "3"])
+
+
+def test_cli_reports_sanitization(monkeypatch, capsys):
+    fortune = pd.DataFrame({"rank": [1, 2], "company": ["A", "B"], "ticker": ["A", "B"]})
+
+    monkeypatch.setattr(
+        cli,
+        "_build_universe_step",
+        lambda args: cli.BuildUniverseResult(["A", "B"], fortune, duration=0.0),
+    )
+
+    def fake_download(args, tickers):
+        return cli.DownloadPricesResult(
+            prices=pd.DataFrame(),
+            close=pd.DataFrame(),
+            tickers=["A"],
+            dropped_short=["B"],
+            dropped_duplicate=[],
+            duration=0.0,
+        )
+
+    monkeypatch.setattr(cli, "_download_prices_step", fake_download)
+    monkeypatch.setattr(
+        cli,
+        "_compute_metrics_step",
+        lambda args, prices_result, fortune_df: cli.ComputeMetricsResult(
+            result=pd.DataFrame(
+                {"rank": [1], "company": ["A"], args.metric: [0.1]}, index=["A"]
+            ),
+            duration=0.0,
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_render_output_step",
+        lambda args, compute_result: cli.RenderOutputResult(duration=0.0),
+    )
+
+    cli.main(["--print-top", "1"])
+    output = capsys.readouterr().out
+    assert "Sanitized price matrix" in output

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -2,11 +2,13 @@ import re
 import subprocess
 import sys
 
+import pandas as pd
 import pytest
 
-pytest.skip("integration test requires selenium and network", allow_module_level=True)
+from highest_volatility.app import cli
 
 
+@pytest.mark.skip(reason="integration test requires selenium and network")
 def test_cli_prints_200_rows():
     cmd = [
         sys.executable,
@@ -22,4 +24,48 @@ def test_cli_prints_200_rows():
     # Count data lines that start with an uppercase ticker-like token
     lines = [ln for ln in r.stdout.splitlines() if re.match(r"^[A-Z0-9\.-]+\s+", ln)]
     assert len(lines) == 200, f"Expected 200 rows, got {len(lines)}\nSTDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
+
+
+def test_main_orchestrates_steps(monkeypatch, capsys):
+    fortune = pd.DataFrame({"ticker": ["A"], "company": ["A Co"], "rank": [1]})
+
+    monkeypatch.setattr(
+        cli,
+        "_build_universe_step",
+        lambda args: cli.BuildUniverseResult(["A"], fortune, duration=0.1),
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "_download_prices_step",
+        lambda args, tickers: cli.DownloadPricesResult(
+            prices=pd.DataFrame(),
+            close=pd.DataFrame(),
+            tickers=["A"],
+            dropped_short=[],
+            dropped_duplicate=[],
+            duration=0.2,
+        ),
+    )
+
+    df = pd.DataFrame({"rank": [1], "company": ["A Co"], "cc_vol": [0.3]}, index=["A"])
+    monkeypatch.setattr(
+        cli,
+        "_compute_metrics_step",
+        lambda args, prices_result, fortune_df: cli.ComputeMetricsResult(
+            result=df,
+            duration=0.3,
+        ),
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "_render_output_step",
+        lambda args, compute_result: (print("Rendered"), cli.RenderOutputResult(duration=0.4))[1],
+    )
+
+    cli.main(["--print-top", "1", "--timings"])
+    output = capsys.readouterr().out
+    assert "Rendered" in output
+    assert "Timings:" in output
 

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from highest_volatility.app.sanitization import sanitize_close
+
+
+def test_sanitize_close_drops_duplicates_and_short_series():
+    idx = pd.date_range("2023-01-01", periods=5)
+    close = pd.DataFrame(
+        {
+            "KEEP": [1, 2, 3, 4, 5],
+            "DUPE": [1, 2, 3, 4, 5],
+            "SHORT": [1, None, None, None, None],
+        },
+        index=idx,
+    )
+
+    clean, short, duplicate = sanitize_close(close, min_days=3)
+
+    assert list(clean.columns) == ["KEEP"]
+    assert short == ["SHORT"]
+    assert duplicate == ["DUPE"]


### PR DESCRIPTION
## Summary
- extract the price sanitisation routine into `highest_volatility.app.sanitization.sanitize_close`
- split the CLI `main` workflow into `_build_universe_step`, `_download_prices_step`, `_compute_metrics_step`, and `_render_output_step` dataclass-backed helpers
- expand CLI-focused tests (unit, guard, integration stubs) and add dedicated sanitisation coverage while documenting rollback instructions

## Testing
- `pytest tests/test_cli.py tests/test_cli_integration.py tests/test_cli_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68d006bf8488832880c63987df0cedb9