### PR TITLE
Refactor universe builder into helper pipeline

### DIFF
--- a/tests/test_universe_rank_alignment.py
+++ b/tests/test_universe_rank_alignment.py
@@ -1,10 +1,16 @@
-from __future__ import annotations
 
 from typing import Iterable
 
 import pandas as pd
+import pytest
 
-from highest_volatility.universe import build_universe
+from highest_volatility.universe import (
+    FortuneData,
+    _align_ranks,
+    _deduplicate_symbols,
+    _normalize_fortune,
+    build_universe,
+)
 
 
 def test_cached_rank_alignment_uses_normalized_index(monkeypatch):
@@ -30,3 +36,98 @@ def test_cached_rank_alignment_uses_normalized_index(monkeypatch):
     assert tickers == ["BRK-B"]
     assert list(fortune["ticker"]) == ["BRK-B"]
     assert list(fortune["rank"]) == [7]
+
+
+def test_normalize_fortune_sorts_and_normalizes():
+    data = FortuneData(
+        pd.DataFrame(
+            [
+                {"rank": 5, "company": "Beta", "ticker": " beta "},
+                {"rank": 1, "company": "Alpha", "ticker": "A"},
+            ]
+        )
+    )
+
+    normalized = _normalize_fortune(data)
+
+    assert list(normalized.frame["rank"]) == [1, 5]
+    assert list(normalized.frame["ticker"]) == ["A", "beta"]
+    assert list(normalized.frame["normalized_ticker"]) == ["A", "BETA"]
+
+
+@pytest.mark.parametrize(
+    "rows, expected_companies, expected_tickers",
+    [
+        (
+            [
+                {"company": "Valid", "ticker": "GOOD", "normalized_ticker": "GOOD"},
+                {"company": "Valid", "ticker": "GOOD", "normalized_ticker": "GOOD"},
+                {"company": "Bad", "ticker": "bad", "normalized_ticker": "bad"},
+                {"company": "Other", "ticker": "OT-H1", "normalized_ticker": "OT-H1"},
+            ],
+            ["Valid", "Other"],
+            ["GOOD", "OT-H1"],
+        ),
+        (
+            [
+                {"company": "Also", "ticker": "ALSO", "normalized_ticker": "ALSO"},
+                {"company": "Extra", "ticker": "EXTRA/", "normalized_ticker": "EXTRA/"},
+            ],
+            ["Also"],
+            ["ALSO"],
+        ),
+    ],
+)
+def test_deduplicate_symbols_filters_invalid(rows, expected_companies, expected_tickers):
+    fortune = FortuneData(pd.DataFrame(rows))
+
+    companies, tickers = _deduplicate_symbols(fortune)
+
+    assert companies == expected_companies
+    assert tickers == expected_tickers
+
+
+def test_align_ranks_falls_back_to_enumeration_when_lookup_fails():
+    data = FortuneData(
+        pd.DataFrame(
+            [
+                {"rank": 3, "company": "Gamma", "ticker": "G", "normalized_ticker": "G"},
+            ]
+        )
+    )
+
+    fortune = _align_ranks(
+        data,
+        companies=["Missing"],
+        tickers=["MISSING"],
+    )
+
+    assert list(fortune["rank"]) == [1]
+    assert list(fortune["company"]) == ["Missing"]
+    assert list(fortune["ticker"]) == ["MISSING"]
+
+
+def test_align_ranks_uses_existing_ranks_when_available():
+    frame = pd.DataFrame(
+        [
+            {
+                "rank": 2,
+                "company": "Alpha",
+                "ticker": "A",
+                "normalized_ticker": "A",
+            },
+            {
+                "rank": 4,
+                "company": "Beta",
+                "ticker": "B",
+                "normalized_ticker": "B",
+            },
+        ]
+    )
+    data = FortuneData(frame)
+
+    fortune = _align_ranks(data, companies=["Beta"], tickers=["B"])
+
+    assert list(fortune["rank"]) == [4]
+    assert list(fortune["company"]) == ["Beta"]
+    assert list(fortune["ticker"]) == ["B"]

--- a/tests/test_universe_size.py
+++ b/tests/test_universe_size.py
@@ -1,13 +1,64 @@
+import builtins
+from typing import Iterable
+
+import pandas as pd
 import pytest
 
-from highest_volatility.universe import build_universe
+from highest_volatility.universe import (
+    FortuneData,
+    _load_cached_fortune,
+    _validate_history,
+    build_universe,
+)
 
 
-pytest.skip("requires selenium and internet access", allow_module_level=True)
+def test_load_cached_fortune_returns_none_when_missing(monkeypatch):
+    monkeypatch.setattr(
+        "highest_volatility.universe.load_cached_fortune",
+        lambda *args, **kwargs: None,
+    )
+
+    result = _load_cached_fortune(first_n_fortune=10, ticker_cache_days=1)
+    assert result is None
 
 
+def test_load_cached_fortune_wraps_dataframe(monkeypatch):
+    def fake_loader(*_: Iterable, **__: dict) -> pd.DataFrame:
+        return pd.DataFrame([{"rank": 1, "company": "A", "ticker": "A"}])
+
+    monkeypatch.setattr(
+        "highest_volatility.universe.load_cached_fortune",
+        fake_loader,
+    )
+    monkeypatch.setattr(builtins, "print", lambda *args, **kwargs: None)
+
+    result = _load_cached_fortune(first_n_fortune=5, ticker_cache_days=30)
+    assert isinstance(result, FortuneData)
+    assert list(result.frame["ticker"]) == ["A"]
+
+
+@pytest.mark.parametrize(
+    "tickers, validate, expected",
+    [
+        ([], True, set()),
+        (["ONE"], False, {"ONE"}),
+    ],
+)
+def test_validate_history_respects_flag(monkeypatch, tickers, validate, expected):
+    monkeypatch.setattr(
+        "highest_volatility.universe._validate_tickers_have_history",
+        lambda tkrs: [t.lower() for t in tkrs],
+    )
+
+    result = _validate_history(tickers, validate=validate)
+    if validate:
+        assert result == {t.lower() for t in tickers}
+    else:
+        assert result == expected
+
+
+@pytest.mark.skip("requires selenium and internet access")
 def test_universe_has_at_least_300_public_tickers():
     # Live test: requires Chrome, internet access
-    tickers, fortune = build_universe(first_n_fortune=300)
+    tickers, _ = build_universe(first_n_fortune=300)
     assert len(tickers) >= 300, f"Only got {len(tickers)} tickers"
-


### PR DESCRIPTION
## Summary
- extract the universe builder workflow into dedicated helpers and a `FortuneData` dataclass so the control flow in `build_universe` reads as a linear pipeline
- keep cache scraping, normalization, deduplication, validation, and ranking logic identical while relocating the defensive logging/error handling into the appropriate helper
- expand the universe tests to exercise the new helpers directly and keep the rank-alignment regression covered

## Testing
- pytest tests/test_universe_rank_alignment.py tests/test_universe_size.py

## Helper extraction
- `build_universe` now delegates to `_load_cached_fortune`, `_scrape_fortune`, `_normalize_fortune`, `_deduplicate_symbols`, `_validate_history`, and `_align_ranks`

## Rollback plan
- revert commit `819aaec` or restore the prior monolithic `build_universe` implementation from the previous revision of `src/highest_volatility/universe.py`, removing the helper invocations and dataclass.


------
https://chatgpt.com/codex/tasks/task_e_68d008fe88f883289f9cc12f7d1ee434