### PR TITLE
Enforce API parameter bounds

### DIFF
--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api import app as cache_app
@@ -31,3 +32,49 @@ def test_metrics_rejects_header_injection() -> None:
             "referrer-policy",
         ):
             assert header in resp.headers
+
+
+def test_prices_rejects_excessive_lookback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.highest_volatility.app.api.download_price_history",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("download_price_history should not be invoked")
+        ),
+    )
+    with TestClient(hv_app) as client:
+        resp = client.get(
+            "/prices",
+            params={"tickers": "AAPL", "lookback_days": 5000},
+        )
+        assert resp.status_code == 400
+
+
+def test_metrics_rejects_excessive_min_days(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.highest_volatility.app.api.download_price_history",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("download_price_history should not be invoked")
+        ),
+    )
+    with TestClient(hv_app) as client:
+        resp = client.get(
+            "/metrics",
+            params={"tickers": "AAPL", "metric": "cc_vol", "min_days": 1000},
+        )
+        assert resp.status_code == 400
+
+
+def test_prices_rejects_excessive_ticker_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "src.highest_volatility.app.api.download_price_history",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("download_price_history should not be invoked")
+        ),
+    )
+    tickers = ",".join(f"T{i}" for i in range(101))
+    with TestClient(hv_app) as client:
+        resp = client.get(
+            "/prices",
+            params={"tickers": tickers},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add a reusable positive integer sanitizer with optional bounds for API inputs
- enforce lookback/min/top_n ranges and ticker count limits in the FastAPI endpoints
- cover excessive lookback, min-days, and ticker count scenarios in API security tests

## Testing
- pytest tests/test_api_security.py

------
https://chatgpt.com/codex/tasks/task_e_68d01066e54c8328b5c92bf2ff724fb0