### PR TITLE
Handle metric compute errors

### DIFF
--- a/src/highest_volatility/app/api.py
+++ b/src/highest_volatility/app/api.py
@@ -35,6 +35,7 @@ from highest_volatility.app.cli import (
 )
 from highest_volatility.compute.metrics import METRIC_REGISTRY
 from highest_volatility.errors import (
+    ComputeError,
     ErrorCode,
     HVError,
     IntegrationError,
@@ -299,7 +300,7 @@ def metrics_endpoint(
     except Exception as exc:
         error = wrap_error(
             exc,
-            IntegrationError,
+            ComputeError,
             message="Metric computation failed",
             context={"metric": met, "tickers": len(ticker_list)},
         )


### PR DESCRIPTION
## Summary
- wrap unexpected metric computation failures as ComputeError to surface HTTP 500 responses
- add regression test ensuring metrics endpoint logs compute errors and returns 500
- adjust existing error resilience test inputs to satisfy validation constraints

## Testing
- pytest tests/test_error_resilience.py

------
https://chatgpt.com/codex/tasks/task_e_68d013e633dc8328a315031369250dd6