### PR TITLE
Point Docker image at packaged API entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 EXPOSE 8000
-CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV PYTHONPATH="/app/src"
+
+CMD [
+    "uvicorn",
+    "highest_volatility.app.api:app",
+    "--host",
+    "0.0.0.0",
+    "--port",
+    "8000",
+]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ universe. Build and run it with Docker:
 
 ```bash
 docker build -t hv-api .
-docker run -p 8000:8000 hv-api
+docker run --rm -p 8000:8000 hv-api
 ```
+
+Runtime notes:
+
+- The container publishes the API on port ``8000``; map it to a host port as
+  needed (for example ``-p 8000:8000``).
+- ``PYTHONPATH`` is set to ``/app/src`` so ``highest_volatility`` can be
+  imported without installing the package separately.
+- Override any FastAPI settings with ``HV_``-prefixed environment variables.
+  Common examples include ``HV_REDIS_URL`` (default ``redis://localhost:6379/0``)
+  and ``HV_CACHE_REFRESH_INTERVAL``.
 
 The service provides two endpoints:
 


### PR DESCRIPTION
## Summary
- configure the container to expose the FastAPI application via `highest_volatility.app.api:app`
- ensure the packaged sources are importable by exporting `PYTHONPATH=/app/src`
- document the updated Docker run command and runtime environment expectations in the README

## Testing
- `docker build -t hv-api .` *(fails: docker: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01a3bbfac83288a8f3575f807e5d8