### PR TITLE
Update cache refresh documentation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ configured with the ``HV_CACHE_REFRESH_INTERVAL`` environment variable and
 defaults to once every 24 hours.
 
 A helper script is provided to refresh cached price data for all locally stored
-tickers.  It iterates over the tickers under `.cache/prices/<interval>` and
-updates each one sequentially.
+tickers. It iterates over the tickers under `cache/prices/<interval>` and
+updates each one sequentially. Each ticker's Parquet file and JSON manifest
+live side by side in that directory (for example, `AAPL.parquet` and
+`AAPL.json`), matching the `_paths` helper in `src/cache/store.py`.
 
 Run the scheduler from the repository root:
 


### PR DESCRIPTION
## Summary
- correct the cache refresh instructions to reference the cache/prices/<interval> directory
- clarify that each ticker's manifest sits beside its Parquet file as implemented in src/cache/store.py

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d01badcd388328bf794d6ba30b31af