### PR TITLE
Expose ingest downloader helpers as public API

### DIFF
--- a/src/highest_volatility/ingest/prices.py
+++ b/src/highest_volatility/ingest/prices.py
@@ -91,7 +91,7 @@ def download_price_history(
     )
 
     if matrix_mode == "batch":
-        batch_result = downloaders._download_batch(batch_request, download_with_retry)
+        batch_result = downloaders.download_batch(batch_request, download_with_retry)
         return batch_result.to_dataframe(trim_start=start_dt)
 
     if matrix_mode == "async":
@@ -111,16 +111,16 @@ def download_price_history(
             max_workers=max_workers,
             datasource_factory=_datasource_factory,
         )
-        async_result = asyncio.run(downloaders._download_async(async_request))
+        async_result = asyncio.run(downloaders.download_async(async_request))
         return async_result.to_dataframe(trim_start=start_dt)
 
     if not use_cache or load_cached is None or save_cache is None or merge_incremental is None:
-        batch_result = downloaders._download_batch(batch_request, download_with_retry)
+        batch_result = downloaders.download_batch(batch_request, download_with_retry)
         return batch_result.to_dataframe(trim_start=start_dt)
 
     cache_end_date = date.today()
     cache_start_date = cache_end_date - timedelta(days=lookback_days * 2)
-    cache_plan = downloaders._plan_cache_fetch(
+    cache_plan = downloaders.plan_cache_fetch(
         tickers=tickers,
         interval=interval,
         start_date=cache_start_date,
@@ -132,7 +132,7 @@ def download_price_history(
 
     frames: Dict[str, pd.DataFrame] = dict(cache_plan.frames)
 
-    cache_result = downloaders._execute_cache_fetch(
+    cache_result = downloaders.execute_cache_fetch(
         cache_plan,
         download_with_retry,
         prepost=prepost,
@@ -143,11 +143,11 @@ def download_price_history(
     frames.update(cache_result.frames)
 
     if not frames:
-        batch_result = downloaders._download_batch(batch_request, download_with_retry)
+        batch_result = downloaders.download_batch(batch_request, download_with_retry)
         return batch_result.to_dataframe(trim_start=start_dt)
 
-    fingerprint_plan = downloaders._plan_fingerprint_refresh(frames, lookback_days=lookback_days)
-    fingerprint_result = downloaders._execute_fingerprint_refresh(
+    fingerprint_plan = downloaders.plan_fingerprint_refresh(frames, lookback_days=lookback_days)
+    fingerprint_result = downloaders.execute_fingerprint_refresh(
         fingerprint_plan,
         download_with_retry=download_with_retry,
         interval=interval,

--- a/tests/test_prices_cache_policy.py
+++ b/tests/test_prices_cache_policy.py
@@ -167,7 +167,7 @@ def test_plan_cache_fetch_force_refresh():
         assert interval == "1d"
         return cached_df.copy(), None
 
-    plan = downloaders._plan_cache_fetch(
+    plan = downloaders.plan_cache_fetch(
         tickers=["AAA"],
         interval="1d",
         start_date=date(2024, 4, 1),
@@ -191,6 +191,6 @@ def test_plan_fingerprint_refresh_detects_clusters():
         "DDD": pd.DataFrame({"Adj Close": range(10, 20)}, index=idx),
     }
 
-    plan = downloaders._plan_fingerprint_refresh(frames, lookback_days=40)
+    plan = downloaders.plan_fingerprint_refresh(frames, lookback_days=40)
     assert set(plan.suspects) == {"AAA", "BBB", "CCC"}
     assert plan.field == "Adj Close"


### PR DESCRIPTION
## Summary
- promote the ingest download helper functions to public snake_case names and export them via `__all__`
- keep legacy underscore-prefixed aliases for compatibility while updating prices orchestration and tests to use the new API
- refresh documentation strings to describe the public helpers and their deprecated aliases

## Testing
- `pytest tests/test_prices_cache_policy.py tests/test_prices_async.py`
- `pytest tests/test_price_fetcher.py tests/test_prices_batch_concurrency.py tests/test_async_fetcher.py tests/test_cache_refresh_resilience.py`


------
https://chatgpt.com/codex/tasks/task_e_68d01fd98f8083289e6cc4e17d4d20c4