### PR TITLE
Improve cache configurability and async data retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ tickers. It iterates over the tickers under `cache/prices/<interval>` and
 updates each one sequentially. Each ticker's Parquet file and JSON manifest
 live side by side in that directory (for example, `AAPL.parquet` and
 `AAPL.json`), matching the `_paths` helper in `highest_volatility/cache/store.py`.
+Set the ``HV_CACHE_ROOT`` environment variable to point cache storage to an
+alternate location when deploying on ephemeral filesystems or managed hosts.
 
 Run the scheduler from the repository root:
 

--- a/src/highest_volatility/cache/store.py
+++ b/src/highest_volatility/cache/store.py
@@ -19,8 +19,15 @@ from highest_volatility.security.validation import (
     sanitize_single_ticker,
 )
 
-# Default on-disk cache root. Use project-visible folder as requested.
-CACHE_ROOT = Path("cache/prices")
+# Default on-disk cache root. Use project-visible folder unless overridden.
+def _resolve_cache_root() -> Path:
+    env_root = os.getenv("HV_CACHE_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+    return Path("cache/prices")
+
+
+CACHE_ROOT = _resolve_cache_root()
 
 
 @dataclass

--- a/src/highest_volatility/datasource/yahoo_async.py
+++ b/src/highest_volatility/datasource/yahoo_async.py
@@ -36,17 +36,58 @@ class YahooAsyncDataSource(AsyncDataSource):
         if not timestamps:
             raise ValueError("Empty data returned")
         indicators = result.get("indicators", {})
-        series = None
+        quote = indicators.get("quote")
+        quote_block: Dict[str, list[Any]] = quote[0] if isinstance(quote, list) and quote else {}
+        opens = quote_block.get("open")
+        highs = quote_block.get("high")
+        lows = quote_block.get("low")
+        closes = quote_block.get("close")
+        volumes = quote_block.get("volume")
+
+        adj_values = None
         adj = indicators.get("adjclose")
         if isinstance(adj, list) and adj:
-            series = adj[0].get("adjclose")
-        if series is None:
-            quote = indicators.get("quote")
-            if isinstance(quote, list) and quote:
-                series = quote[0].get("close")
-        if not series:
+            adj_values = adj[0].get("adjclose")
+
+        if adj_values is None and closes is None:
             raise ValueError("Missing adjclose/close in Yahoo response")
-        df = pd.DataFrame({"Adj Close": series}, index=pd.to_datetime(timestamps, unit="s"))
+
+        def _value_at(values: list[Any] | None, idx: int) -> Any:
+            if values is None or idx >= len(values):
+                return None
+            value = values[idx]
+            if value is None or pd.isna(value):
+                return None
+            return value
+
+        rows: list[dict[str, Any]] = []
+        retained: list[int] = []
+        for idx, ts in enumerate(timestamps):
+            adj_value = _value_at(adj_values, idx)
+            close_value = _value_at(closes, idx)
+            price_value = adj_value if adj_value is not None else close_value
+            if price_value is None:
+                continue
+            row = {
+                "Open": _value_at(opens, idx),
+                "High": _value_at(highs, idx),
+                "Low": _value_at(lows, idx),
+                "Close": close_value if close_value is not None else price_value,
+                "Adj Close": price_value,
+                "Volume": _value_at(volumes, idx),
+            }
+            for key in ("Open", "High", "Low"):
+                if row[key] is None:
+                    row[key] = price_value
+            if row["Volume"] is None:
+                row["Volume"] = 0
+            rows.append(row)
+            retained.append(ts)
+
+        if not rows:
+            raise ValueError("Empty data returned")
+
+        df = pd.DataFrame(rows, index=pd.to_datetime(retained, unit="s"))
         return df.sort_index()
 
     async def validate_ticker(self, ticker: str) -> bool:

--- a/src/highest_volatility/datasource/yahoo_http_async.py
+++ b/src/highest_volatility/datasource/yahoo_http_async.py
@@ -73,43 +73,55 @@ class YahooHTTPAsyncDataSource(AsyncDataSource):
         if not timestamps:
             raise ValueError("Empty data returned")
         indicators = result.get("indicators", {})
-        adj_values = None
-        quote_values = None
+        quote = indicators.get("quote")
+        quote_block: Dict[str, list[Any]] = quote[0] if isinstance(quote, list) and quote else {}
+        opens = quote_block.get("open")
+        highs = quote_block.get("high")
+        lows = quote_block.get("low")
+        closes = quote_block.get("close")
+        volumes = quote_block.get("volume")
 
+        adj_values = None
         adj = indicators.get("adjclose")
         if isinstance(adj, list) and adj:
             adj_values = adj[0].get("adjclose")
 
-        quote = indicators.get("quote")
-        if isinstance(quote, list) and quote:
-            quote_values = quote[0].get("close")
-
-        if adj_values is None and quote_values is None:
+        if adj_values is None and closes is None:
             raise ValueError("Missing adjclose/close in Yahoo response")
 
         def _value_at(values: list[Any] | None, idx: int) -> Any:
             if values is None or idx >= len(values):
                 return None
-            return values[idx]
+            value = values[idx]
+            if value is None or pd.isna(value):
+                return None
+            return value
 
-        combined: list[Any] = []
+        rows: list[dict[str, Any]] = []
         retained_timestamps: list[int] = []
         missing_indices: list[int] = []
-        for idx in range(len(timestamps)):
+        for idx, ts in enumerate(timestamps):
             adj_value = _value_at(adj_values, idx)
-            close_value = _value_at(quote_values, idx)
-
-            if adj_value is not None:
-                combined.append(adj_value)
-                retained_timestamps.append(timestamps[idx])
+            close_value = _value_at(closes, idx)
+            price_value = adj_value if adj_value is not None else close_value
+            if price_value is None:
+                missing_indices.append(idx)
                 continue
-
-            if close_value is not None:
-                combined.append(close_value)
-                retained_timestamps.append(timestamps[idx])
-                continue
-
-            missing_indices.append(idx)
+            row = {
+                "Open": _value_at(opens, idx),
+                "High": _value_at(highs, idx),
+                "Low": _value_at(lows, idx),
+                "Close": close_value if close_value is not None else price_value,
+                "Adj Close": price_value,
+                "Volume": _value_at(volumes, idx),
+            }
+            for key in ("Open", "High", "Low"):
+                if row[key] is None:
+                    row[key] = price_value
+            if row["Volume"] is None:
+                row["Volume"] = 0
+            rows.append(row)
+            retained_timestamps.append(ts)
 
         missing_timestamps = [
             pd.to_datetime(timestamps[i], unit="s", utc=True).isoformat()
@@ -123,15 +135,13 @@ class YahooHTTPAsyncDataSource(AsyncDataSource):
                 missing_timestamps,
             )
 
-        if not combined:
+        if not rows:
             raise ValueError(
                 "Missing adjclose/close data for ticker "
                 f"{ticker} at timestamps {missing_timestamps}"
             )
 
-        df = pd.DataFrame(
-            {"Adj Close": combined}, index=pd.to_datetime(retained_timestamps, unit="s")
-        )
+        df = pd.DataFrame(rows, index=pd.to_datetime(retained_timestamps, unit="s"))
         if df.isna().any().any():
             def _to_iso(ts: pd.Timestamp) -> str:
                 ts = pd.Timestamp(ts)

--- a/tests/test_cache_store.py
+++ b/tests/test_cache_store.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pandas as pd
 import pytest
 
@@ -23,3 +25,14 @@ def test_round_trip(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError):
         store.save_cache("DEF", "1d", df.iloc[0:0], "test")
+
+
+def test_cache_root_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "custom-cache"
+    monkeypatch.setenv("HV_CACHE_ROOT", str(target))
+    reloaded = importlib.reload(store)
+    try:
+        assert reloaded.CACHE_ROOT == target
+    finally:
+        monkeypatch.delenv("HV_CACHE_ROOT", raising=False)
+        importlib.reload(store)

--- a/tests/test_prices_cache_policy.py
+++ b/tests/test_prices_cache_policy.py
@@ -58,6 +58,26 @@ def _install_cache_stubs(
     return starts, saved, full_backfill_calls
 
 
+def test_batch_mode_honors_use_cache(monkeypatch):
+    today = date(2020, 1, 10)
+    _setup_time(monkeypatch, today)
+    expected_start = date(2020, 1, 1)
+    starts, saved, calls = _install_cache_stubs(monkeypatch, expected_start, "1d", "D")
+
+    df = prices.download_price_history(
+        ["AAA"],
+        5,
+        matrix_mode="batch",
+        use_cache=True,
+        max_workers=1,
+    )
+
+    assert calls == [("1d", today)]
+    assert [pd.Timestamp(s).date() for s in starts] == [expected_start]
+    assert ("AAA", "1d") in saved
+    assert not df.empty
+
+
 def test_first_run_cache_uses_full_backfill_daily(monkeypatch):
     today = date(2020, 1, 10)
     _setup_time(monkeypatch, today)


### PR DESCRIPTION
## Summary
- ensure batch matrix mode honours the cache plan instead of bypassing it
- emit complete OHLCV frames from async Yahoo adapters and keep valid rows when auxiliary data is missing
- allow overriding the cache root via `HV_CACHE_ROOT` with regression tests and updated docs

## Testing
- pytest tests/test_prices_cache_policy.py -q
- pytest tests/test_async_fetcher.py -q
- pytest tests/test_cache_store.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d02745d9e48328b58bd7d791ec3ed0