### PR TITLE
Add Selenium-related runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ dependencies = [
     "pydantic-settings",
     "httpx",
     "pandas-market-calendars",
+    "numpy",
+    "requests",
+    "selenium",
+    "selenium-stealth",
+    "webdriver-manager",
 ]
 
 [project.optional-dependencies]

--- a/src/highest_volatility.egg-info/PKG-INFO
+++ b/src/highest_volatility.egg-info/PKG-INFO
@@ -20,6 +20,11 @@ Requires-Dist: streamlit
 Requires-Dist: pydantic-settings
 Requires-Dist: httpx
 Requires-Dist: pandas-market-calendars
+Requires-Dist: numpy
+Requires-Dist: requests
+Requires-Dist: selenium
+Requires-Dist: selenium-stealth
+Requires-Dist: webdriver-manager
 Provides-Extra: dev
 Requires-Dist: pytest; extra == "dev"
 Requires-Dist: pytest-asyncio; extra == "dev"

--- a/src/highest_volatility.egg-info/requires.txt
+++ b/src/highest_volatility.egg-info/requires.txt
@@ -15,6 +15,11 @@ streamlit
 pydantic-settings
 httpx
 pandas-market-calendars
+numpy
+requests
+selenium
+selenium-stealth
+webdriver-manager
 
 [dev]
 pytest


### PR DESCRIPTION
## Summary
- add numpy, requests, selenium, selenium-stealth, and webdriver-manager as runtime dependencies in pyproject.toml
- regenerate project metadata so PKG-INFO and requires.txt list the new Requires-Dist entries
- build fresh sdist and wheel to confirm the published artifacts carry the added requirements

## Testing
- `pip install -e .`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_68d1556940fc8328bc85ba941d195e70