### PR TITLE
Configure setuptools to discover src packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ dev = [
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["highest_volatility*"]
+
 [tool.ruff]
 src = ["src"]
 target-version = "py310"

--- a/src/highest_volatility.egg-info/top_level.txt
+++ b/src/highest_volatility.egg-info/top_level.txt
@@ -1,4 +1,1 @@
-__init__
-api
-cli
 highest_volatility


### PR DESCRIPTION
## Summary
- configure setuptools to treat the repository as a src-layout package and only discover `highest_volatility` modules
- regenerate project metadata so the recorded top-level package list matches the expected layout

## Testing
- `pip install -e .`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_68d15a80673c8328821e1e2dfcdd9b51