### PR TITLE
Add Altair dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "altair",
     "pandas",
     "pyarrow",
     "yfinance",

--- a/src/highest_volatility.egg-info/PKG-INFO
+++ b/src/highest_volatility.egg-info/PKG-INFO
@@ -3,6 +3,7 @@ Name: highest_volatility
 Version: 1.0.0
 Requires-Python: >=3.10
 Description-Content-Type: text/markdown
+Requires-Dist: altair
 Requires-Dist: pandas
 Requires-Dist: pyarrow
 Requires-Dist: yfinance

--- a/src/highest_volatility.egg-info/requires.txt
+++ b/src/highest_volatility.egg-info/requires.txt
@@ -1,3 +1,4 @@
+altair
 pandas
 pyarrow
 yfinance


### PR DESCRIPTION
## Summary
- add Altair to the project dependencies so that Streamlit visualizations can run
- refresh the editable installation to capture the new requirement in egg-info metadata

## Testing
- pip install -e .

------
https://chatgpt.com/codex/tasks/task_e_68d15bc4157c8328819d4c39e035a385