### PR TITLE
Align API imports with highest_volatility.app

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -53,6 +53,7 @@ def _alias_namespace(old: str, new: str) -> None:
 
 
 for _old, _new in {
+    "src.api": "highest_volatility.app.api",
     "src.cache": "highest_volatility.cache",
     "src.config": "highest_volatility.config",
     "src.datasource": "highest_volatility.datasource",

--- a/src/highest_volatility/api/__init__.py
+++ b/src/highest_volatility/api/__init__.py
@@ -1,5 +1,5 @@
 """Expose the cache API under the :mod:`highest_volatility` namespace."""
 
-from src.api import app
+from highest_volatility.app.api import app
 
 __all__ = ["app"]

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -7,9 +7,18 @@ from highest_volatility.api import app as cache_app
 from highest_volatility.app.api import app as hv_app
 
 
+def test_highest_volatility_api_reexports_main_app() -> None:
+    """Ensure ``highest_volatility.api`` exposes the production FastAPI app."""
+
+    assert cache_app is hv_app
+    routes = {route.path for route in cache_app.routes}
+    assert "/metrics" in routes
+    assert "/prices" in routes
+
+
 def test_prices_rejects_traversal() -> None:
     with TestClient(cache_app) as client:
-        resp = client.get("/prices/AAPL", params={"interval": "../"})
+        resp = client.get("/prices", params={"tickers": "AAPL", "interval": "../"})
         assert resp.status_code == 400
         assert "invalid" in resp.json()["detail"].lower()
         for header in (


### PR DESCRIPTION
## Summary
- re-export the FastAPI application from `highest_volatility.app.api`
- alias the legacy `src.api` import path to the new module
- add a regression test ensuring the API module exposes the production routes

## Testing
- pytest tests/test_api_security.py

------
https://chatgpt.com/codex/tasks/task_e_68d16657292083288973da3a2bed9ff5