### PR TITLE
Stop tracking build outputs and require modern packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ cache/
 .cache/
 src/.cache/
 mypy.ini
+dist/
+build/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools"]
+requires = [
+    "setuptools>=68",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add dist/ and build/ to .gitignore to keep build artifacts out of version control
- require modern setuptools and wheel in pyproject.toml to satisfy packaging tooling

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68d17598171c832891db39176a8f0942