### PR TITLE
Align requirements with project dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ streamlit
 pydantic-settings
 httpx
 pandas-market-calendars
+altair
+joblib
+python-dateutil
+pandas-datareader


### PR DESCRIPTION
## Summary
- add the missing runtime dependencies to requirements.txt so they match pyproject metadata

## Testing
- pip install -r requirements.txt
- streamlit run src/highest_volatility/app/streamlit_app.py --server.headless true

------
https://chatgpt.com/codex/tasks/task_e_68d1788ab80c832899726bf8b136bf45