### PR TITLE
Add reliability testing harness and resilience safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The service provides several HTTP endpoints documented in
 [`docs/api.md`](docs/api.md). Refer to that guide for request/response schemas,
 error handling behaviour, and configuration options. Reliability commitments,
 error budgets, and alerting flows for the FastAPI layer and the ingestion jobs
-live in [`docs/reliability/slo.md`](docs/reliability/slo.md). Keep SLO dashboards
+live in [`docs/reliability/slo.md`](docs/reliability/slo.md). Operational drills,
+chaos experiments, and performance tooling are detailed in
+[`docs/reliability/testing.md`](docs/reliability/testing.md). Keep SLO dashboards
 and Alertmanager rules version-controlled alongside deployments and rerun
 `scripts/deploy_dashboards.py` after each release to ensure Grafana panels and
 PagerDuty routes reflect the current configuration.

--- a/docs/reliability/testing.md
+++ b/docs/reliability/testing.md
@@ -1,0 +1,93 @@
+# Reliability Test Playbook
+
+This guide explains how to exercise the new resilience, chaos, and performance
+tooling introduced for the Highest Volatility platform.
+
+## Prerequisites
+
+- Python 3.10+ with the project dependencies installed (`pip install -r
+  requirements.txt`).
+- Optional: Locust for load tests (`pip install locust==2.24.1`) or use the
+  `perf` extras group (`pip install .[perf]`).
+- A running instance of the FastAPI service. The examples assume the default
+  development server bound to `http://localhost:8000`.
+
+## Chaos Experiments (Pytest)
+
+Targeted experiments live in `tests/test_chaos_experiments.py` and are marked
+with the `chaos` marker.
+
+```bash
+pytest -m chaos tests/test_chaos_experiments.py
+```
+
+What the suite covers:
+
+1. **Redis outage** – forces a cache backend failure during startup and asserts
+   the service falls back to the in-memory cache while staying within the 500 ms
+   API latency SLO.
+2. **Data-source outage** – simulates upstream price feed failures and verifies
+   502 responses are returned quickly with metrics recorded against the
+   `DATA_SOURCE` error code.
+3. **Cache-refresh cancellation** – injects cancellation into the periodic cache
+   refresh loop and checks that it exits without logging failure events.
+
+These tests execute quickly (<1 second each) and can run inside the existing CI
+pipeline alongside unit tests. Add the following step to GitHub Actions, Azure
+Pipelines, or similar systems after the unit test job:
+
+```yaml
+- name: Chaos experiments
+  run: pytest -m chaos tests/test_chaos_experiments.py
+```
+
+## Performance and Soak Testing (Locust)
+
+Locust scenarios are defined under `tests/performance/`.
+
+1. **Configuration** – environment variables override defaults:
+   - `HV_PERF_BASE_URL` (default `http://localhost:8000`)
+   - `HV_PERF_TICKERS` (comma-separated, default `AAPL,MSFT,GOOGL,AMZN,TSLA`)
+   - `HV_PERF_METRIC` (default `cc_vol`)
+   - `HV_PERF_LOOKBACK_DAYS` (default `90`)
+   - `HV_PERF_MIN_DAYS` (default `60`)
+   - `HV_PERF_STAGE_DURATION` (seconds, default `300`)
+   - `HV_PERF_RAMP_USERS` (default `25`)
+   - `HV_PERF_STEADY_USERS` (default `75`)
+   - `HV_PERF_SLO_MS` (per-request latency SLO, default `500`)
+
+2. **Run a headless soak**:
+
+   ```bash
+   locust -f tests/performance/locustfile.py \
+     --headless \
+     -u "$HV_PERF_STEADY_USERS" \
+     -r 5 \
+     -t 30m
+   ```
+
+   The `RampAndSoakShape` automatically handles warm-up, soak, and ramp-down
+   phases while failing any request that breaches the latency SLO.
+
+3. **Scheduled execution** – integrate into CI/CD by running Locust as a gated
+   job or a nightly soak:
+
+   ```yaml
+   - name: Nightly soak test
+     if: github.event_name == 'schedule'
+     run: |
+       pip install .[perf]
+       locust -f tests/performance/locustfile.py --headless -t 45m
+   ```
+
+Locust exit codes reflect success/failure, allowing pipelines to fail if the SLO
+is breached or if requests error.
+
+## Observability Hooks
+
+- Performance runs emit Locust request failures tagged with `SLO` when latency
+  exceeds the configured threshold, providing immediate visibility in test
+  reports.
+- Chaos experiments rely on the existing `ErrorCode` metrics to confirm outages
+  are measured and budgets tracked against the SLO catalogue documented in
+  `docs/reliability/slo.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dev = [
     "mypy",
     "hypothesis",
 ]
+perf = [
+    "locust==2.24.1",
+]
 
 [build-system]
 requires = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ asyncio_mode = auto
 python_files = test_*.py
 markers =
     asyncio: mark test as asyncio (pytest-asyncio)
+    chaos: reliability and fault-injection experiments
 filterwarnings =
     ignore:.*DataFrame.pct_change.*:FutureWarning
     ignore:.*utcfromtimestamp\(\).*:DeprecationWarning:dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ altair
 joblib
 python-dateutil
 pandas-datareader
+locust==2.24.1

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance scenarios executed via Locust."""

--- a/tests/performance/config.py
+++ b/tests/performance/config.py
@@ -1,0 +1,44 @@
+"""Configuration helpers for performance testing."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PerfConfig:
+    """Locust configuration derived from environment variables."""
+
+    base_url: str
+    tickers: str
+    metric: str
+    lookback_days: int
+    min_days: int
+    stage_duration: int
+    ramp_users: int
+    steady_users: int
+    target_slo_ms: int
+
+    @classmethod
+    def load(cls) -> "PerfConfig":
+        base_url = os.getenv("HV_PERF_BASE_URL", "http://localhost:8000")
+        tickers = os.getenv("HV_PERF_TICKERS", "AAPL,MSFT,GOOGL,AMZN,TSLA")
+        metric = os.getenv("HV_PERF_METRIC", "cc_vol")
+        lookback_days = int(os.getenv("HV_PERF_LOOKBACK_DAYS", "90"))
+        min_days = int(os.getenv("HV_PERF_MIN_DAYS", "60"))
+        stage_duration = int(os.getenv("HV_PERF_STAGE_DURATION", "300"))
+        ramp_users = int(os.getenv("HV_PERF_RAMP_USERS", "25"))
+        steady_users = int(os.getenv("HV_PERF_STEADY_USERS", "75"))
+        target_slo_ms = int(os.getenv("HV_PERF_SLO_MS", "500"))
+        return cls(
+            base_url=base_url,
+            tickers=tickers,
+            metric=metric,
+            lookback_days=lookback_days,
+            min_days=min_days,
+            stage_duration=stage_duration,
+            ramp_users=ramp_users,
+            steady_users=steady_users,
+            target_slo_ms=target_slo_ms,
+        )

--- a/tests/performance/locustfile.py
+++ b/tests/performance/locustfile.py
@@ -1,0 +1,91 @@
+"""Locust scenarios for load and soak testing the public API endpoints."""
+
+from __future__ import annotations
+
+from locust import HttpUser, LoadTestShape, between, events, task
+
+from .config import PerfConfig
+
+
+CONFIG = PerfConfig.load()
+
+
+@events.request.add_listener
+def enforce_slo(
+    request_type,
+    name,
+    response_time,
+    response_length,
+    response,
+    context,
+    exception,
+    **kwargs,
+):
+    """Mark requests exceeding the SLO as failures without aborting the run."""
+
+    if exception or response_time <= CONFIG.target_slo_ms:
+        return
+    events.request_failure.fire(
+        request_type=request_type,
+        name=f"{name} (SLO {CONFIG.target_slo_ms}ms)",
+        response_time=response_time,
+        response_length=response_length,
+        exception=AssertionError(
+            f"SLO breach: {name} took {response_time:.0f}ms "
+            f"(limit {CONFIG.target_slo_ms}ms)"
+        ),
+    )
+
+
+class VolatilityUser(HttpUser):
+    """User journey exercising `/prices` and `/metrics` endpoints."""
+
+    host = CONFIG.base_url
+    wait_time = between(1.0, 3.0)
+
+    @task(3)
+    def prices(self) -> None:
+        self.client.get(
+            "/prices",
+            name="/prices",
+            params={
+                "tickers": CONFIG.tickers,
+                "lookback_days": CONFIG.lookback_days,
+            },
+        )
+
+    @task(1)
+    def metrics(self) -> None:
+        self.client.get(
+            "/metrics",
+            name="/metrics",
+            params={
+                "tickers": CONFIG.tickers,
+                "metric": CONFIG.metric,
+                "lookback_days": CONFIG.lookback_days,
+                "min_days": CONFIG.min_days,
+            },
+        )
+
+
+class RampAndSoakShape(LoadTestShape):
+    """Ramp up to target throughput, soak, then gracefully ramp down."""
+
+    def __init__(self):
+        super().__init__()
+        spawn_ramp = max(1, CONFIG.ramp_users // max(1, CONFIG.stage_duration // 10))
+        spawn_steady = max(1, CONFIG.steady_users // max(1, CONFIG.stage_duration // 10))
+        self._stages = [
+            {"length": CONFIG.stage_duration, "users": CONFIG.ramp_users, "spawn": spawn_ramp},
+            {"length": CONFIG.stage_duration * 2, "users": CONFIG.steady_users, "spawn": spawn_steady},
+            {"length": CONFIG.stage_duration, "users": 0, "spawn": spawn_ramp},
+        ]
+
+    def tick(self):
+        run_time = self.get_run_time()
+        elapsed = 0
+        for stage in self._stages:
+            elapsed += stage["length"]
+            if run_time < elapsed:
+                return stage["users"], stage["spawn"]
+        return None

--- a/tests/test_chaos_experiments.py
+++ b/tests/test_chaos_experiments.py
@@ -1,0 +1,131 @@
+"""Chaos experiments ensuring graceful degradation under infrastructure faults."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pandas as pd
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.inmemory import InMemoryBackend
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from highest_volatility.app import api as hv_api
+from highest_volatility.errors import (
+    DataSourceError,
+    ErrorCode,
+    get_error_metrics,
+    reset_error_metrics,
+)
+from highest_volatility.pipeline import cache_refresh
+
+
+API_SLO_SECONDS = 0.5
+pytestmark = pytest.mark.chaos
+
+
+@pytest.fixture(autouse=True)
+def _stub_schedule(monkeypatch):
+    """Prevent the real refresh scheduler from running during the tests."""
+
+    async def _noop_schedule(*args, **kwargs):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(hv_api, "schedule_cache_refresh", _noop_schedule)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_cache_backend():
+    """Ensure ``FastAPICache`` does not leak state across tests."""
+
+    try:
+        await FastAPICache.clear()
+    except AssertionError:
+        pass
+    yield
+    try:
+        await FastAPICache.clear()
+    except AssertionError:
+        pass
+
+
+def _stub_prices_dataframe() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=5)
+    return pd.DataFrame({"Close": [1, 1.2, 1.3, 1.5, 1.4]}, index=idx)
+
+
+def test_rest_api_survives_redis_outage(monkeypatch):
+    """The API should stay responsive if Redis is unavailable on startup."""
+
+    reset_error_metrics()
+
+    class _BrokenRedis:
+        async def ping(self):
+            raise RedisConnectionError("redis offline")
+
+    monkeypatch.setattr(hv_api.redis, "from_url", lambda *a, **k: _BrokenRedis())
+    monkeypatch.setattr(
+        "highest_volatility.app.api.download_price_history",
+        lambda *a, **k: _stub_prices_dataframe(),
+    )
+
+    with TestClient(hv_api.app) as client:
+        start = time.perf_counter()
+        response = client.get("/prices", params={"tickers": "AAPL", "lookback_days": 30})
+        latency = time.perf_counter() - start
+        assert hv_api.app.state.cache_health == "degraded"
+
+    assert response.status_code == 200
+    assert latency <= API_SLO_SECONDS
+    backend = FastAPICache.get_backend()
+    assert isinstance(backend, InMemoryBackend)
+
+
+def test_prices_endpoint_handles_datasource_outage(monkeypatch):
+    """Even during upstream failures the API should respond quickly with 502."""
+
+    reset_error_metrics()
+
+    def _boom(*args, **kwargs):
+        raise DataSourceError("feed unavailable", context={"tickers": args[0]})
+
+    monkeypatch.setattr(
+        "highest_volatility.app.api.download_price_history",
+        _boom,
+    )
+
+    with TestClient(hv_api.app) as client:
+        start = time.perf_counter()
+        response = client.get("/prices", params={"tickers": "FAIL", "lookback_days": 30})
+        latency = time.perf_counter() - start
+
+    assert response.status_code == 502
+    assert latency <= API_SLO_SECONDS
+    metrics = get_error_metrics()
+    assert metrics.get(ErrorCode.DATA_SOURCE.value, 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_cache_refresh_cancellation_is_not_logged_as_failure(monkeypatch, caplog):
+    """Cancelling the refresh loop should not emit failure events."""
+
+    caplog.clear()
+    caplog.set_level("ERROR", logger="highest_volatility.pipeline.cache_refresh")
+
+    async def _no_op_refresh(*args, **kwargs):
+        await asyncio.sleep(0)
+
+    async def _cancel_sleep(delay):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(cache_refresh, "refresh_cached_prices", _no_op_refresh)
+    monkeypatch.setattr(cache_refresh.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await cache_refresh.schedule_cache_refresh(delay=5)
+
+    failure_events = [rec for rec in caplog.records if "cache_refresh_iteration_failed" in rec.message]
+    assert not failure_events


### PR DESCRIPTION
## Summary
- add an in-memory cache fallback with health metadata when Redis is unavailable and ensure cache refresh cancellation is treated as non-fatal
- introduce pytest-based chaos experiments and Locust ramp/soak scenarios under `tests/performance/`
- document reliability playbooks, new perf configuration knobs, and expose a `perf` extras group for installing Locust

## Testing
- pytest tests/test_chaos_experiments.py -vv
- pytest tests/test_cache_refresh_resilience.py


------
https://chatgpt.com/codex/tasks/task_e_68d17d21428c8328b788bd0bfbc3f81d