### PR TITLE
Add operational health probes for API readiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ COPY . .
 EXPOSE 8000
 ENV PYTHONPATH="/app/src"
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD [\
+    "python",\
+    "-c",\
+    "import sys, urllib.request; resp = urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=4); sys.exit(0 if resp.status == 200 else 1)"\
+]
+
 CMD [
     "uvicorn",
     "highest_volatility.app.api:app",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Runtime notes:
 - Override any FastAPI settings with ``HV_``-prefixed environment variables.
   Common examples include ``HV_REDIS_URL`` (default ``redis://localhost:6379/0``)
   and ``HV_CACHE_REFRESH_INTERVAL``.
+- Container builds now include a Docker ``HEALTHCHECK`` that polls ``/healthz``.
+  Kubernetes operators should also wire ``/readyz`` into readiness probes so
+  nodes only receive traffic once Redis connectivity and background refresh
+  tasks are healthy.
+
+### Operational endpoints
+
+- ``GET /healthz`` – liveness check reporting cache refresh task state and
+  Redis reachability. Returns HTTP 503 if the background worker has failed.
+- ``GET /readyz`` – readiness gate confirming Redis connectivity and a healthy
+  cache backend. Returns HTTP 503 until Redis is reachable and the cache is
+  initialised.
 
 The service provides several HTTP endpoints documented in
 [`docs/api.md`](docs/api.md). Refer to that guide for request/response schemas,

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from highest_volatility.app.api import app
+
+
+class _StubRedisClient:
+    """Lightweight Redis stub supporting ``ping`` and ``close``."""
+
+    def __init__(self, *, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+
+    async def ping(self) -> None:
+        if self.should_fail:
+            raise RedisConnectionError("redis unavailable")
+
+    async def close(self) -> None:  # pragma: no cover - behaviourless stub
+        return None
+
+    async def eval(self, *args: Any, **kwargs: Any) -> int:  # pragma: no cover - stubbed API
+        return 0
+
+
+@contextmanager
+def _instrumented_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    redis_client: _StubRedisClient,
+    refresh_factory: Callable[..., Any],
+) -> Iterator[TestClient]:
+    """Create a :class:`TestClient` with injected Redis and refresh behaviour."""
+
+    monkeypatch.setattr(
+        "highest_volatility.app.api.redis.from_url", lambda *args, **kwargs: redis_client
+    )
+    monkeypatch.setattr(
+        "highest_volatility.app.api.schedule_cache_refresh", refresh_factory
+    )
+    with TestClient(app) as client:
+        yield client
+
+
+async def _noop_refresh(*args: Any, **kwargs: Any) -> None:
+    await asyncio.sleep(0)
+
+
+async def _failing_refresh(*args: Any, **kwargs: Any) -> None:
+    raise RuntimeError("refresh failed")
+
+
+def test_health_and_readyz_report_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Endpoints should report success when Redis and tasks are healthy."""
+
+    redis_client = _StubRedisClient()
+    with _instrumented_client(monkeypatch, redis_client=redis_client, refresh_factory=_noop_refresh) as client:
+        health = client.get("/healthz")
+        assert health.status_code == 200
+        payload = health.json()
+        assert payload["status"] == "ok"
+        assert payload["redis"]["status"] == "up"
+
+        ready = client.get("/readyz")
+        assert ready.status_code == 200
+        ready_payload = ready.json()
+        assert ready_payload["status"] == "ok"
+
+
+def test_readyz_fails_when_redis_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Readiness must fail fast if Redis cannot be contacted."""
+
+    redis_client = _StubRedisClient(should_fail=True)
+    with _instrumented_client(monkeypatch, redis_client=redis_client, refresh_factory=_noop_refresh) as client:
+        health = client.get("/healthz")
+        assert health.status_code == 200
+        health_payload = health.json()
+        assert health_payload["redis"]["status"] == "down"
+
+        ready = client.get("/readyz")
+        assert ready.status_code == 503
+        ready_payload = ready.json()
+        assert ready_payload["redis"]["status"] == "down"
+
+
+def test_healthz_detects_background_task_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed cache refresh task should trip the liveness probe."""
+
+    redis_client = _StubRedisClient()
+    with _instrumented_client(monkeypatch, redis_client=redis_client, refresh_factory=_failing_refresh) as client:
+        time.sleep(0.05)
+        health = client.get("/healthz")
+        assert health.status_code == 503
+        payload = health.json()
+        assert payload["cache_refresh_task"]["status"] == "error"
+
+        ready = client.get("/readyz")
+        assert ready.status_code == 503


### PR DESCRIPTION
## Summary
- add liveness and readiness endpoints that validate Redis connectivity and cache refresh background tasks
- record the resulting probes in Docker healthchecks and reliability documentation for operators
- cover success and failure scenarios with dedicated FastAPI test coverage

## Testing
- pytest tests/test_health_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68d180d04ac48328aaaf255f18f3c8d0