### PR TITLE
feat: allow CLI to skip universe scrape when tickers provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ selected with the ``--metric`` option:
 - ``var`` – value at risk (VaR)
 - ``sortino`` – annualised Sortino ratio
 
+### Supplying explicit tickers
+
+Pass one or more symbols via ``--tickers`` to bypass the Selenium-backed Fortune
+scraper and operate on an ad-hoc universe. The CLI normalises the provided
+strings to uppercase, removes duplicates while preserving order, and skips the
+universe cache refresh. This mirrors the GitHub Actions workflow that refreshes
+prices for a static watchlist each night.
+
 ## CLI Internals & Rollback Plan
 
 The CLI now orchestrates four focused steps – universe construction, price

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -71,6 +71,54 @@ def test_main_orchestrates_steps(monkeypatch, capsys):
     assert "Timings:" in output
 
 
+def test_main_skips_fortune_when_tickers_provided(monkeypatch, capsys):
+    expected = ["AAPL", "MSFT"]
+
+    monkeypatch.setattr(
+        cli,
+        "_build_universe_step",
+        lambda args: (_ for _ in ()).throw(AssertionError("unexpected Fortune scrape")),
+    )
+
+    def fake_download(args, tickers):
+        assert tickers == expected
+        prices = pd.DataFrame(columns=tickers)
+        close = pd.DataFrame(columns=tickers)
+        return cli.DownloadPricesResult(
+            prices=prices,
+            close=close,
+            tickers=tickers,
+            dropped_short=[],
+            dropped_duplicate=[],
+            duration=0.0,
+        )
+
+    monkeypatch.setattr(cli, "_download_prices_step", fake_download)
+
+    def fake_compute(args, prices_result, fortune_df):
+        assert list(fortune_df["ticker"]) == expected
+        assert "company" in fortune_df.columns
+        assert "rank" in fortune_df.columns
+        df = pd.DataFrame({"company": ["Demo"], "rank": [None], "cc_vol": [0.0]}, index=[expected[0]])
+        return cli.ComputeMetricsResult(result=df, duration=0.0)
+
+    monkeypatch.setattr(cli, "_compute_metrics_step", fake_compute)
+
+    rendered: dict[str, pd.DataFrame] = {}
+
+    def fake_render(args, compute_result):
+        rendered["result"] = compute_result.result
+        return cli.RenderOutputResult(duration=0.0)
+
+    monkeypatch.setattr(cli, "_render_output_step", fake_render)
+
+    cli.main(["--tickers", "aapl", "MSFT", "AAPL", "--print-top", "1"])
+
+    output = capsys.readouterr().out
+    assert "Using provided tickers" in output
+    assert rendered["result"].index.tolist() == [expected[0]]
+
+
 def test_public_cli_main_orchestrates(monkeypatch, capsys):
     fortune = pd.DataFrame({"ticker": ["A"], "company": ["A Co"], "rank": [1]})
 

--- a/tests/test_src_cli_parser.py
+++ b/tests/test_src_cli_parser.py
@@ -21,3 +21,15 @@ def test_cli_parser_rejects_removed_intervals(interval):
     parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["--interval", interval, "--tickers", "AAPL"])
+
+
+def test_cli_parser_returns_explicit_tickers():
+    parser = build_parser()
+    args = parser.parse_args(["--tickers", "AAPL", "MSFT"])
+    assert args.tickers == ["AAPL", "MSFT"]
+
+
+def test_cli_parser_rejects_abbreviated_flags():
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--tick", "5", "--tickers", "AAPL"])


### PR DESCRIPTION
## Summary
- disable argparse abbreviations and add an explicit `--tickers` flag to the CLI
- short-circuit the universe scrape when tickers are supplied and document the behaviour
- extend parser and orchestration tests to cover the new flag and flow

## Testing
- pytest tests/test_src_cli_parser.py tests/test_cli_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68d1874828988328ba40e1a8ac9b8cd1