### PR TITLE
Update docs to require highest_volatility imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ loading and caching price history.
 ## Module Layout
 
 Reusable components now live under the unified :mod:`highest_volatility`
-namespace. For example, caching helpers are available from
-``highest_volatility.cache`` and security sanitizers reside in
-``highest_volatility.security``. The historical ``src.*`` namespace has been
-retired; import callers should reference the canonical package modules
-directly.
+namespace. Importers must target the canonical package modules—caching helpers
+are exposed via ``highest_volatility.cache`` and security sanitizers reside in
+``highest_volatility.security``. Compatibility shims for the legacy
+``src.*`` namespace have been removed, so downstream projects need to update
+their imports to the ``highest_volatility.*`` modules before upgrading.
 
 ## Data API
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,13 @@
 # Highest Volatility API Reference
 
 The FastAPI application in `highest_volatility.app.api` exposes operational
-endpoints for working with cached equity data and derived metrics.  Unless
+endpoints for working with cached equity data and derived metrics. This
+maintained module replaces the deprecated `src/api/__init__.py` entry point, so
+deployments must target `highest_volatility.app.api:app` directly. Unless
 otherwise noted, all endpoints respond with JSON and share a common error
-contract described in [Error handling](#error-handling). Deployments should
-run `uvicorn highest_volatility.app.api:app` (or an equivalent ASGI server
-command) to start the service. The table below summarises the exposed routes.
+contract described in [Error handling](#error-handling). Run `uvicorn
+highest_volatility.app.api:app` (or an equivalent ASGI server command) to start
+the service. The table below summarises the exposed routes.
 
 | Method | Path              | Description                             |
 | ------ | ----------------- | --------------------------------------- |


### PR DESCRIPTION
## Summary
- clarify the Module Layout guidance to require `highest_volatility.*` imports now that the legacy `src.*` namespace is gone
- document that `highest_volatility.app.api` replaces the old `src/api/__init__.py` entry point and remains the FastAPI service surface

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1adc55bec8328b8dcde72b0292910