### PR TITLE
Update workflow CLI entry point

### DIFF
--- a/.github/workflows/daily-price-fetch.yml
+++ b/.github/workflows/daily-price-fetch.yml
@@ -30,7 +30,7 @@ jobs:
           intervals=(1m 5m 15m 30m 1h 1d)
           tickers="AAPL MSFT AMZN GOOGL META"
           for intv in "${intervals[@]}"; do
-            until python -m src.cli --interval "$intv" --tickers $tickers; do
+            until python -m highest_volatility.cli --interval "$intv" --tickers $tickers; do
               echo "Retrying $intv..."
               sleep 30
             done


### PR DESCRIPTION
## Summary
- update the daily price fetch workflow to invoke the package CLI module instead of the legacy src namespace

## Testing
- python -m highest_volatility.cli --help
- pytest tests/test_package_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d1b17b48f883289582909a9f10924f