### PR TITLE
Refresh egg-info metadata after removing legacy src namespace

### DIFF
--- a/src/highest_volatility.egg-info/PKG-INFO
+++ b/src/highest_volatility.egg-info/PKG-INFO
@@ -34,6 +34,8 @@ Requires-Dist: vcrpy; extra == "dev"
 Requires-Dist: ruff; extra == "dev"
 Requires-Dist: mypy; extra == "dev"
 Requires-Dist: hypothesis; extra == "dev"
+Provides-Extra: perf
+Requires-Dist: locust==2.24.1; extra == "perf"
 
 # Highest Volatility
 
@@ -43,12 +45,11 @@ loading and caching price history.
 ## Module Layout
 
 Reusable components now live under the unified :mod:`highest_volatility`
-namespace. For example, caching helpers are available from
-``highest_volatility.cache`` and security sanitizers reside in
-``highest_volatility.security``. The legacy ``src.*`` entry points remain
-available via :mod:`sys.modules` aliases so external consumers can migrate
-incrementally, but internal imports and documentation reference the consolidated
-package.
+namespace. Importers must target the canonical package modules—caching helpers
+are exposed via ``highest_volatility.cache`` and security sanitizers reside in
+``highest_volatility.security``. Compatibility shims for the legacy
+``src.*`` namespace have been removed, so downstream projects need to update
+their imports to the ``highest_volatility.*`` modules before upgrading.
 
 ## Data API
 
@@ -69,10 +70,29 @@ Runtime notes:
 - Override any FastAPI settings with ``HV_``-prefixed environment variables.
   Common examples include ``HV_REDIS_URL`` (default ``redis://localhost:6379/0``)
   and ``HV_CACHE_REFRESH_INTERVAL``.
+- Container builds now include a Docker ``HEALTHCHECK`` that polls ``/healthz``.
+  Kubernetes operators should also wire ``/readyz`` into readiness probes so
+  nodes only receive traffic once Redis connectivity and background refresh
+  tasks are healthy.
+
+### Operational endpoints
+
+- ``GET /healthz`` – liveness check reporting cache refresh task state and
+  Redis reachability. Returns HTTP 503 if the background worker has failed.
+- ``GET /readyz`` – readiness gate confirming Redis connectivity and a healthy
+  cache backend. Returns HTTP 503 until Redis is reachable and the cache is
+  initialised.
 
 The service provides several HTTP endpoints documented in
 [`docs/api.md`](docs/api.md). Refer to that guide for request/response schemas,
-error handling behaviour, and configuration options.
+error handling behaviour, and configuration options. Reliability commitments,
+error budgets, and alerting flows for the FastAPI layer and the ingestion jobs
+live in [`docs/reliability/slo.md`](docs/reliability/slo.md). Operational drills,
+chaos experiments, and performance tooling are detailed in
+[`docs/reliability/testing.md`](docs/reliability/testing.md). Keep SLO dashboards
+and Alertmanager rules version-controlled alongside deployments and rerun
+`scripts/deploy_dashboards.py` after each release to ensure Grafana panels and
+PagerDuty routes reflect the current configuration.
 
 ### Validation Notes
 
@@ -121,6 +141,14 @@ selected with the ``--metric`` option:
 - ``max_drawdown`` – maximum drawdown
 - ``var`` – value at risk (VaR)
 - ``sortino`` – annualised Sortino ratio
+
+### Supplying explicit tickers
+
+Pass one or more symbols via ``--tickers`` to bypass the Selenium-backed Fortune
+scraper and operate on an ad-hoc universe. The CLI normalises the provided
+strings to uppercase, removes duplicates while preserving order, and skips the
+universe cache refresh. This mirrors the GitHub Actions workflow that refreshes
+prices for a static watchlist each night.
 
 ## CLI Internals & Rollback Plan
 

--- a/src/highest_volatility.egg-info/SOURCES.txt
+++ b/src/highest_volatility.egg-info/SOURCES.txt
@@ -1,7 +1,5 @@
 README.md
 pyproject.toml
-src/__init__.py
-src/cli.py
 src/highest_volatility/__init__.py
 src/highest_volatility/__main__.py
 src/highest_volatility/cli.py
@@ -60,15 +58,18 @@ tests/test_cache_refresh_resilience.py
 tests/test_cache_store.py
 tests/test_cache_store_validation.py
 tests/test_cache_validation.py
+tests/test_chaos_experiments.py
 tests/test_cli.py
 tests/test_cli_guard.py
 tests/test_cli_integration.py
 tests/test_error_diagnostics.py
 tests/test_error_resilience.py
+tests/test_health_endpoints.py
 tests/test_interval_policy.py
 tests/test_merge_incremental.py
 tests/test_metric_plugins.py
 tests/test_metrics.py
+tests/test_package_bootstrap.py
 tests/test_periods_per_year.py
 tests/test_price_fetcher.py
 tests/test_prices_async.py
@@ -76,7 +77,6 @@ tests/test_prices_batch_concurrency.py
 tests/test_prices_cache_policy.py
 tests/test_sanitization.py
 tests/test_security_validation.py
-tests/test_src_bootstrap.py
 tests/test_src_cli_parser.py
 tests/test_streamlit_app_bootstrap.py
 tests/test_streamlit_exports.py

--- a/src/highest_volatility.egg-info/requires.txt
+++ b/src/highest_volatility.egg-info/requires.txt
@@ -30,3 +30,6 @@ vcrpy
 ruff
 mypy
 hypothesis
+
+[perf]
+locust==2.24.1


### PR DESCRIPTION
## Summary
- regenerate `src/highest_volatility.egg-info` via `python -m build` after removing the stale directory
- refresh `PKG-INFO`, `SOURCES.txt`, and `requires.txt` metadata so only `highest_volatility.*` modules and new extras are recorded

## Testing
- `pytest tests/test_package_bootstrap.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1b4a8747c8328921db0f5833ea6df