### PR TITLE
Remove tracked egg-info metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@ src/.cache/
 mypy.ini
 dist/
 build/
-src/highest_volatility.egg-info/*
-!src/highest_volatility.egg-info/PKG-INFO
+src/highest_volatility.egg-info/
 


### PR DESCRIPTION
## Summary
- drop the checked-in `src/highest_volatility.egg-info/PKG-INFO` metadata artifact
- ignore the regenerated egg-info directory entirely so future builds stop reintroducing it

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1bdd7365883289040d4549dcbfad2