### PR TITLE
Add PWA client with offline sync and Playwright coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dev = [
     "ruff",
     "mypy",
     "hypothesis",
+    "pytest-playwright",
+    "playwright",
 ]
 perf = [
     "locust==2.24.1",

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ python_files = test_*.py
 markers =
     asyncio: mark test as asyncio (pytest-asyncio)
     chaos: reliability and fault-injection experiments
+    e2e: end-to-end browser validation
 filterwarnings =
     ignore:.*DataFrame.pct_change.*:FutureWarning
     ignore:.*utcfromtimestamp\(\).*:DeprecationWarning:dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ selenium-stealth
 pyarrow
 pytest
 pytest-asyncio
+pytest-playwright
+playwright
 aiohttp
 tenacity
 fastapi

--- a/src/highest_volatility/web/__init__.py
+++ b/src/highest_volatility/web/__init__.py
@@ -1,0 +1,5 @@
+"""Progressive web client for Highest Volatility."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/src/highest_volatility/web/data-layer.js
+++ b/src/highest_volatility/web/data-layer.js
@@ -1,0 +1,207 @@
+import {
+  addMutation,
+  deleteMutation,
+  getAllMutations,
+  appendAudit,
+  getAuditTrail,
+} from "./db.js";
+
+const nowIsoString = () => new Date().toISOString();
+
+export class DataLayer {
+  constructor({ baseUrl }) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+  }
+
+  async loadUniverse() {
+    const payload = await this.#fetchJson("/universe");
+    return payload.tickers ?? [];
+  }
+
+  async loadAnnotations() {
+    try {
+      const payload = await this.#fetchJson("/annotations");
+      return Array.isArray(payload) ? payload : [];
+    } catch (error) {
+      await appendAudit({
+        timestamp: nowIsoString(),
+        type: "annotations_error",
+        detail: String(error?.message ?? error),
+      });
+      return [];
+    }
+  }
+
+  async saveAnnotation(ticker, note) {
+    const sanitizedTicker = String(ticker ?? "").trim().toUpperCase();
+    if (!sanitizedTicker) {
+      throw new Error("Ticker is required");
+    }
+    const trimmedNote = String(note ?? "").trim();
+    if (!trimmedNote) {
+      throw new Error("Note cannot be empty");
+    }
+
+    const mutation = await addMutation({
+      type: "annotation",
+      ticker: sanitizedTicker,
+      note: trimmedNote,
+      clientTimestamp: nowIsoString(),
+    });
+
+    this.#notifyServiceWorker({ type: "STORE_MUTATION", mutation });
+
+    await appendAudit({
+      timestamp: nowIsoString(),
+      type: "queued",
+      detail: `Queued annotation for ${sanitizedTicker}`,
+      mutationId: mutation.id,
+    });
+
+    if (navigator.onLine) {
+      await this.syncPendingMutations();
+    }
+
+    return mutation;
+  }
+
+  async syncPendingMutations() {
+    const pending = await getAllMutations();
+    if (!pending.length) {
+      return { applied: 0, conflicts: [] };
+    }
+
+    let serverAnnotations = [];
+    try {
+      serverAnnotations = await this.loadAnnotations();
+    } catch (error) {
+      await appendAudit({
+        timestamp: nowIsoString(),
+        type: "sync_failed",
+        detail: `Failed to load annotations before sync: ${String(error)}`,
+      });
+      throw error;
+    }
+
+    const byTicker = new Map(serverAnnotations.map((item) => [item.ticker, item]));
+    const conflicts = [];
+    let applied = 0;
+
+    for (const mutation of pending) {
+      if (mutation.type !== "annotation") {
+        continue;
+      }
+      const serverRecord = byTicker.get(mutation.ticker);
+      const mutationTime = new Date(mutation.clientTimestamp ?? 0).getTime();
+      const serverTime = serverRecord ? new Date(serverRecord.updated_at ?? 0).getTime() : 0;
+
+      if (!serverRecord || mutationTime > serverTime) {
+        try {
+          const response = await this.#fetchJson(`/annotations/${encodeURIComponent(mutation.ticker)}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              note: mutation.note,
+              client_timestamp: mutation.clientTimestamp,
+            }),
+          });
+          applied += 1;
+          byTicker.set(response.ticker, response);
+          await deleteMutation(mutation.id);
+          await appendAudit({
+            timestamp: nowIsoString(),
+            type: "applied",
+            detail: `Applied annotation for ${mutation.ticker}`,
+            mutationId: mutation.id,
+          });
+        } catch (error) {
+          await appendAudit({
+            timestamp: nowIsoString(),
+            type: "sync_failed",
+            detail: `Failed to apply mutation for ${mutation.ticker}: ${String(error)}`,
+            mutationId: mutation.id,
+          });
+        }
+      } else {
+        conflicts.push({
+          ticker: mutation.ticker,
+          mutationTimestamp: mutation.clientTimestamp,
+          serverTimestamp: serverRecord.updated_at,
+          serverNote: serverRecord.note,
+        });
+        await deleteMutation(mutation.id);
+        await appendAudit({
+          timestamp: nowIsoString(),
+          type: "conflict",
+          detail: `Server version kept for ${mutation.ticker}`,
+          mutationId: mutation.id,
+        });
+      }
+    }
+
+    return { applied, conflicts };
+  }
+
+  async getMergedAnnotations() {
+    const [server, pending, audit] = await Promise.all([
+      this.loadAnnotations(),
+      getAllMutations(),
+      getAuditTrail(100),
+    ]);
+
+    const merged = new Map(server.map((item) => [item.ticker, { ...item, pending: false }]));
+
+    for (const mutation of pending) {
+      if (mutation.type !== "annotation") {
+        continue;
+      }
+      const existing = merged.get(mutation.ticker);
+      const mutationTime = new Date(mutation.clientTimestamp ?? 0).getTime();
+      const existingTime = existing ? new Date(existing.updated_at ?? 0).getTime() : 0;
+      if (!existing || mutationTime > existingTime) {
+        merged.set(mutation.ticker, {
+          ticker: mutation.ticker,
+          note: mutation.note,
+          updated_at: mutation.clientTimestamp,
+          pending: true,
+        });
+      }
+    }
+
+    const items = Array.from(merged.values()).sort((a, b) => a.ticker.localeCompare(b.ticker));
+    return { items, pending, audit };
+  }
+
+  async #fetchJson(path, options = undefined) {
+    const url = `${this.baseUrl}${path}`;
+    const response = await fetch(url, {
+      credentials: "same-origin",
+      cache: "no-store",
+      ...options,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Request failed (${response.status}): ${text}`);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    return response.json();
+  }
+
+  #notifyServiceWorker(message) {
+    if (!navigator.serviceWorker) {
+      return;
+    }
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        if (registration.active) {
+          registration.active.postMessage(message);
+        }
+      })
+      .catch(() => {
+        // Ignore service worker registration issues in unsupported environments.
+      });
+  }
+}
+

--- a/src/highest_volatility/web/db.js
+++ b/src/highest_volatility/web/db.js
@@ -1,0 +1,109 @@
+const DB_NAME = "hv-pwa";
+const DB_VERSION = 1;
+export const MUTATION_STORE = "mutations";
+export const AUDIT_STORE = "audit";
+
+const uuidv4 = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11)
+    .replace(/[018]/g, (c) => (c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16));
+};
+
+function promisifyRequest(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+}
+
+function openDatabase() {
+  return new Promise((resolve, reject) => {
+    if (!("indexedDB" in globalThis)) {
+      reject(new Error("IndexedDB is not available in this environment"));
+      return;
+    }
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(MUTATION_STORE)) {
+        db.createObjectStore(MUTATION_STORE, { keyPath: "id" });
+      }
+      if (!db.objectStoreNames.contains(AUDIT_STORE)) {
+        db.createObjectStore(AUDIT_STORE, { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB"));
+  });
+}
+
+async function withStore(storeName, mode, callback) {
+  const db = await openDatabase();
+  try {
+    const tx = db.transaction(storeName, mode);
+    const store = tx.objectStore(storeName);
+    const result = await callback(store);
+    await new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed"));
+      tx.onabort = () => reject(tx.error ?? new Error("IndexedDB transaction aborted"));
+    });
+    return result;
+  } finally {
+    db.close();
+  }
+}
+
+export async function addMutation(record) {
+  const mutation = { ...record, id: record.id ?? uuidv4() };
+  await withStore(MUTATION_STORE, "readwrite", (store) => {
+    store.put(mutation);
+  });
+  return mutation;
+}
+
+export async function deleteMutation(id) {
+  await withStore(MUTATION_STORE, "readwrite", (store) => {
+    store.delete(id);
+  });
+}
+
+export async function getAllMutations() {
+  return withStore(MUTATION_STORE, "readonly", (store) => {
+    const request = store.getAll();
+    return promisifyRequest(request).then((items) =>
+      (items ?? []).sort((a, b) => {
+        return new Date(a.clientTimestamp ?? 0).getTime() - new Date(b.clientTimestamp ?? 0).getTime();
+      })
+    );
+  });
+}
+
+export async function clearMutations() {
+  await withStore(MUTATION_STORE, "readwrite", (store) => {
+    store.clear();
+  });
+}
+
+export async function appendAudit(entry) {
+  const payload = { ...entry, id: entry.id ?? uuidv4() };
+  await withStore(AUDIT_STORE, "readwrite", (store) => {
+    store.put(payload);
+  });
+  return payload;
+}
+
+export async function getAuditTrail(limit = 50) {
+  return withStore(AUDIT_STORE, "readonly", (store) => {
+    const request = store.getAll();
+    return promisifyRequest(request).then((items) => {
+      const sorted = (items ?? []).sort((a, b) => {
+        return new Date(b.timestamp ?? 0).getTime() - new Date(a.timestamp ?? 0).getTime();
+      });
+      return sorted.slice(0, limit);
+    });
+  });
+}
+

--- a/src/highest_volatility/web/icon.svg
+++ b/src/highest_volatility/web/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a8a" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#bg)" />
+  <polyline
+    fill="none"
+    stroke="#38bdf8"
+    stroke-width="10"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    points="24,88 46,68 64,78 86,40 104,52"
+  />
+  <circle cx="86" cy="40" r="8" fill="#fbbf24" />
+</svg>

--- a/src/highest_volatility/web/main.js
+++ b/src/highest_volatility/web/main.js
@@ -1,0 +1,217 @@
+import { DataLayer } from "./data-layer.js";
+
+const dataLayer = new DataLayer({ baseUrl: window.location.origin });
+window.hvDataLayer = dataLayer;
+
+const connectionStatusEl = document.getElementById("connection-status");
+const pendingCountEl = document.getElementById("pending-count");
+const universeListEl = document.getElementById("universe-list");
+const annotationsContainerEl = document.getElementById("annotations-container");
+const auditListEl = document.getElementById("audit-list");
+const refreshUniverseButton = document.getElementById("refresh-universe");
+const refreshAnnotationsButton = document.getElementById("refresh-annotations");
+const syncButton = document.getElementById("sync-button");
+const syncFeedbackEl = document.getElementById("sync-feedback");
+
+const formatTimestamp = (value) => {
+  if (!value) {
+    return "unknown";
+  }
+  try {
+    const date = new Date(value);
+    return date.toLocaleString();
+  } catch (error) {
+    return value;
+  }
+};
+
+const updateConnectionStatus = () => {
+  const online = navigator.onLine;
+  connectionStatusEl.textContent = online ? "Online" : "Offline";
+  connectionStatusEl.classList.toggle("online", online);
+  connectionStatusEl.classList.toggle("offline", !online);
+};
+
+const registerServiceWorker = async () => {
+  if (!("serviceWorker" in navigator)) {
+    return;
+  }
+  try {
+    await navigator.serviceWorker.register("/service-worker.js", { type: "module" });
+    navigator.serviceWorker.addEventListener("message", (event) => {
+      const { type, count } = event.data ?? {};
+      if (type === "mutation-queue" && typeof count === "number") {
+        pendingCountEl.textContent = count.toString();
+      }
+      if (type === "mutation-stored") {
+        syncFeedbackEl.textContent = "Stored offline update. It'll sync when online.";
+      }
+    });
+  } catch (error) {
+    console.warn("Service worker registration failed", error);
+  }
+};
+
+const renderUniverse = (tickers) => {
+  universeListEl.innerHTML = "";
+  annotationsContainerEl.innerHTML = "";
+  tickers.forEach((ticker) => {
+    const li = document.createElement("li");
+    li.textContent = ticker;
+    universeListEl.appendChild(li);
+
+    const card = document.createElement("div");
+    card.className = "annotation-card";
+    card.dataset.ticker = ticker;
+
+    const heading = document.createElement("h3");
+    heading.textContent = ticker;
+
+    const textarea = document.createElement("textarea");
+    textarea.name = `note-${ticker}`;
+    textarea.placeholder = "Add a note";
+
+    const actions = document.createElement("div");
+    actions.className = "actions";
+
+    const saveButton = document.createElement("button");
+    saveButton.type = "button";
+    saveButton.dataset.action = "save";
+    saveButton.dataset.ticker = ticker;
+    saveButton.textContent = "Save";
+
+    const status = document.createElement("p");
+    status.className = "meta";
+    status.dataset.role = "status";
+    status.textContent = "No annotations yet.";
+
+    actions.appendChild(saveButton);
+    card.appendChild(heading);
+    card.appendChild(textarea);
+    card.appendChild(actions);
+    card.appendChild(status);
+    annotationsContainerEl.appendChild(card);
+  });
+};
+
+const renderAnnotations = ({ items, pending, audit }) => {
+  pendingCountEl.textContent = pending.length.toString();
+  items.forEach((item) => {
+    const card = annotationsContainerEl.querySelector(`[data-ticker="${item.ticker}"]`);
+    if (!card) {
+      return;
+    }
+    const textarea = card.querySelector("textarea");
+    const status = card.querySelector('[data-role="status"]');
+    textarea.value = item.note ?? "";
+    if (item.pending) {
+      status.textContent = `Pending sync · updated ${formatTimestamp(item.updated_at)}`;
+    } else {
+      status.textContent = `Synced · updated ${formatTimestamp(item.updated_at)}`;
+    }
+  });
+
+  auditListEl.innerHTML = "";
+  audit.forEach((entry) => {
+    const li = document.createElement("li");
+    li.classList.add(entry.type ?? "");
+    li.textContent = `[${formatTimestamp(entry.timestamp)}] ${entry.detail ?? entry.type}`;
+    auditListEl.appendChild(li);
+  });
+};
+
+const refreshUniverse = async () => {
+  try {
+    const tickers = await dataLayer.loadUniverse();
+    renderUniverse(tickers.slice(0, 12));
+  } catch (error) {
+    syncFeedbackEl.textContent = `Failed to load universe: ${error.message}`;
+  }
+  await refreshAnnotations();
+};
+
+const refreshAnnotations = async () => {
+  const merged = await dataLayer.getMergedAnnotations();
+  renderAnnotations(merged);
+};
+
+const bindEvents = () => {
+  refreshUniverseButton.addEventListener("click", () => {
+    refreshUniverse();
+  });
+
+  refreshAnnotationsButton.addEventListener("click", () => {
+    refreshAnnotations();
+  });
+
+  syncButton.addEventListener("click", async () => {
+    syncButton.disabled = true;
+    syncFeedbackEl.textContent = "Syncing…";
+    try {
+      const result = await dataLayer.syncPendingMutations();
+      if (result.conflicts.length) {
+        syncFeedbackEl.textContent = `Sync completed with ${result.conflicts.length} conflict(s).`;
+      } else {
+        syncFeedbackEl.textContent = "Sync completed.";
+      }
+    } catch (error) {
+      syncFeedbackEl.textContent = `Sync failed: ${error.message}`;
+    } finally {
+      syncButton.disabled = false;
+      await refreshAnnotations();
+    }
+  });
+
+  annotationsContainerEl.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLButtonElement)) {
+      return;
+    }
+    if (target.dataset.action !== "save") {
+      return;
+    }
+    const card = target.closest(".annotation-card");
+    if (!card) {
+      return;
+    }
+    const textarea = card.querySelector("textarea");
+    const ticker = target.dataset.ticker;
+    if (!ticker) {
+      return;
+    }
+    try {
+      await dataLayer.saveAnnotation(ticker, textarea.value);
+      syncFeedbackEl.textContent = `Queued note for ${ticker}.`;
+    } catch (error) {
+      syncFeedbackEl.textContent = `Unable to save note: ${error.message}`;
+    } finally {
+      await refreshAnnotations();
+    }
+  });
+};
+
+const bootstrap = async () => {
+  await registerServiceWorker();
+  updateConnectionStatus();
+  await refreshUniverse();
+};
+
+window.addEventListener("online", async () => {
+  updateConnectionStatus();
+  syncFeedbackEl.textContent = "Connection restored. Syncing…";
+  try {
+    await dataLayer.syncPendingMutations();
+  } catch (error) {
+    syncFeedbackEl.textContent = `Sync failed after reconnect: ${error.message}`;
+  } finally {
+    await refreshAnnotations();
+  }
+});
+
+window.addEventListener("offline", () => {
+  updateConnectionStatus();
+  syncFeedbackEl.textContent = "You are offline. Changes will be queued.";
+});
+
+bindEvents();
+bootstrap();

--- a/src/highest_volatility/web/manifest.webmanifest
+++ b/src/highest_volatility/web/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Highest Volatility Offline Console",
+  "short_name": "HV Offline",
+  "description": "Explore cached market data, annotate tickers, and sync changes once you're back online.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "icons": [
+    {
+      "src": "/web/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/highest_volatility/web/service-worker.js
+++ b/src/highest_volatility/web/service-worker.js
@@ -1,0 +1,161 @@
+import { addMutation, getAllMutations } from "./db.js";
+
+const STATIC_CACHE = "hv-static-v1";
+const DATA_CACHE = "hv-data-v1";
+const CORE_ASSETS = [
+  "/",
+  "/web/main.js",
+  "/web/data-layer.js",
+  "/web/db.js",
+  "/web/styles.css",
+  "/web/icon.svg",
+  "/manifest.webmanifest",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(CORE_ASSETS)).catch(() => undefined)
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key !== STATIC_CACHE && key !== DATA_CACHE)
+          .map((key) => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (request.method === "GET") {
+    if (url.origin === self.location.origin) {
+      if (isStaticAsset(url.pathname)) {
+        event.respondWith(cacheFirst(request));
+        return;
+      }
+      if (isApiRequest(url.pathname)) {
+        event.respondWith(networkWithCacheFallback(request));
+        return;
+      }
+    }
+    return;
+  }
+
+  if (url.origin === self.location.origin) {
+    event.respondWith(handleMutationRequest(event));
+  }
+});
+
+self.addEventListener("message", (event) => {
+  const { type, mutation } = event.data ?? {};
+  if (type === "STORE_MUTATION" && mutation) {
+    event.waitUntil(storeMutation(mutation));
+  }
+  if (type === "SYNC_MUTATIONS") {
+    event.waitUntil(notifyQueueLength());
+  }
+});
+
+const isStaticAsset = (pathname) => {
+  return (
+    pathname === "/" ||
+    pathname.startsWith("/web/") ||
+    pathname === "/manifest.webmanifest"
+  );
+};
+
+const isApiRequest = (pathname) => {
+  return ["/universe", "/metrics", "/prices", "/annotations"].some((prefix) =>
+    pathname.startsWith(prefix)
+  );
+};
+
+const cacheFirst = async (request) => {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+  if (cached) {
+    return cached;
+  }
+  const response = await fetch(request);
+  cache.put(request, response.clone());
+  return response;
+};
+
+const networkWithCacheFallback = async (request) => {
+  const cache = await caches.open(DATA_CACHE);
+  try {
+    const response = await fetch(request);
+    cache.put(request, response.clone());
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) {
+      return cached;
+    }
+    throw error;
+  }
+};
+
+const handleMutationRequest = async (event) => {
+  const { request } = event;
+  try {
+    return await fetch(request.clone());
+  } catch (error) {
+    const mutation = await storeRequest(request);
+    await notifyClients({ type: "mutation-stored", mutation });
+    return new Response(
+      JSON.stringify({ status: "queued", id: mutation.id }),
+      {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+};
+
+const storeRequest = async (request) => {
+  let body = null;
+  try {
+    body = await request.clone().json();
+  } catch (error) {
+    try {
+      body = await request.clone().text();
+    } catch (innerError) {
+      body = null;
+    }
+  }
+  const mutation = await storeMutation({
+    type: "annotation",
+    url: new URL(request.url).pathname,
+    method: request.method,
+    body,
+    clientTimestamp: new Date().toISOString(),
+  });
+  return mutation;
+};
+
+const storeMutation = async (payload) => {
+  const mutation = await addMutation(payload);
+  await notifyQueueLength();
+  return mutation;
+};
+
+const notifyClients = async (message) => {
+  const clients = await self.clients.matchAll({ type: "window" });
+  clients.forEach((client) => client.postMessage(message));
+};
+
+const notifyQueueLength = async () => {
+  const pending = await getAllMutations();
+  await notifyClients({ type: "mutation-queue", count: pending.length });
+};

--- a/src/highest_volatility/web/styles.css
+++ b/src/highest_volatility/web/styles.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+main {
+  padding: 1.5rem;
+  display: grid;
+  gap: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.app-header,
+.app-footer {
+  padding: 1.5rem;
+  text-align: center;
+  background: linear-gradient(135deg, #1f2937, #111827);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  color: #cbd5f5;
+}
+
+.status-panel {
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.status-indicator {
+  font-weight: 600;
+}
+
+.status-indicator.online {
+  color: #34d399;
+}
+
+.status-indicator.offline {
+  color: #f97316;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #2563eb;
+  color: white;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  background: #1d4ed8;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.section-intro {
+  color: #a5b4fc;
+}
+
+.ticker-list {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.ticker-list li {
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 10px;
+  text-align: center;
+  padding: 0.85rem 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.annotation-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.annotation-card {
+  background: rgba(30, 41, 59, 0.8);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.annotation-card textarea {
+  min-height: 80px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.5rem;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  resize: vertical;
+}
+
+.annotation-card .meta {
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.audit-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.audit-list li {
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 10px;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.95rem;
+}
+
+.audit-list li.conflict {
+  border-color: #f97316;
+  color: #fed7aa;
+}
+
+.audit-list li.applied {
+  border-color: #34d399;
+  color: #bbf7d0;
+}
+
+#sync-feedback {
+  min-height: 1.2rem;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 1rem;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+}

--- a/tests/test_pwa_offline.py
+++ b/tests/test_pwa_offline.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from contextlib import closing
+from datetime import datetime, timezone
+
+import httpx
+import pandas as pd
+import pytest
+import uvicorn
+from playwright.sync_api import Page
+
+
+def _find_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        _, port = sock.getsockname()
+    return int(port)
+
+
+@pytest.fixture(scope="session")
+def _apply_app_overrides() -> None:
+    from pytest import MonkeyPatch
+
+    from highest_volatility.app import api as api_module
+
+    monkeypatch = MonkeyPatch()
+
+    async def fake_schedule_cache_refresh(*_: object, **__: object) -> None:
+        await asyncio.sleep(0)
+
+    def fake_build_universe(limit: int, *, validate: bool = True) -> tuple[list[str], pd.DataFrame]:
+        tickers = ["AAPL", "MSFT", "GOOG", "TSLA"]
+        fortune = pd.DataFrame(
+            {
+                "rank": list(range(1, len(tickers) + 1)),
+                "company": ["Alpha", "Beta", "Gamma", "Delta"],
+                "ticker": tickers,
+            }
+        )
+        return tickers[:limit], fortune.iloc[:limit].copy()
+
+    async def fake_download_price_history(*_: object, **__: object) -> pd.DataFrame:
+        index = pd.date_range(datetime.now(tz=timezone.utc) - pd.Timedelta(days=4), periods=5, freq="D")
+        return pd.DataFrame({"Close": [100, 101, 102, 103, 104]}, index=index)
+
+    monkeypatch.setattr(api_module, "schedule_cache_refresh", fake_schedule_cache_refresh, raising=False)
+    monkeypatch.setattr(api_module, "build_universe", fake_build_universe, raising=True)
+    monkeypatch.setattr(api_module, "download_price_history", fake_download_price_history, raising=False)
+
+    yield
+
+    monkeypatch.undo()
+
+
+@pytest.fixture(scope="session")
+def uvicorn_server(_apply_app_overrides: None) -> str:
+    port = _find_free_port()
+    config = uvicorn.Config(
+        "highest_volatility.app.api:app",
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 30
+    with httpx.Client() as client:
+        while time.time() < deadline:
+            try:
+                response = client.get(f"{base_url}/healthz", timeout=1)
+            except httpx.HTTPError:
+                time.sleep(0.2)
+                continue
+            if response.status_code in (200, 503):
+                break
+        else:  # pragma: no cover - defensive timeout guard
+            raise RuntimeError("Timed out waiting for uvicorn to start")
+
+    yield base_url
+
+    server.should_exit = True
+    thread.join(timeout=10)
+    if thread.is_alive():  # pragma: no cover - defensive cleanup
+        raise RuntimeError("uvicorn thread failed to exit")
+
+
+@pytest.mark.e2e
+def test_pwa_offline_sync(page: Page, uvicorn_server: str) -> None:
+    page.set_default_timeout(10000)
+    base_url = uvicorn_server
+
+    page.goto(f"{base_url}/", wait_until="networkidle")
+    page.wait_for_selector("#annotations-container .annotation-card")
+    page.wait_for_function("navigator.serviceWorker && navigator.serviceWorker.controller")
+
+    page.evaluate("async () => await window.hvDataLayer.syncPendingMutations()")
+    page.wait_for_timeout(200)
+
+    page.context.set_offline(True)
+    page.wait_for_selector("text=Offline")
+
+    note_area = page.locator('[data-ticker="AAPL"] textarea')
+    note_area.fill("client-offline-note")
+    page.locator('[data-ticker="AAPL"] button[data-action="save"]').click()
+    page.wait_for_timeout(300)
+
+    pending = page.evaluate("async () => (await window.hvDataLayer.getMergedAnnotations()).pending.length")
+    assert pending >= 1
+
+    page.click("#refresh-universe")
+    page.wait_for_timeout(300)
+    assert page.locator('[data-ticker="AAPL"]').is_visible()
+
+    time.sleep(0.3)
+    with httpx.Client() as client:
+        response = client.put(
+            f"{base_url}/annotations/AAPL",
+            json={"note": "server-wins", "client_timestamp": datetime.utcnow().isoformat()},
+            timeout=5,
+        )
+        assert response.status_code == 200
+
+    page.context.set_offline(False)
+    page.wait_for_selector("text=Online")
+
+    sync_result = page.evaluate("async () => await window.hvDataLayer.syncPendingMutations()")
+    assert sync_result["conflicts"], "Expected at least one conflict during sync"
+
+    merged = page.evaluate("async () => await window.hvDataLayer.getMergedAnnotations()")
+    assert merged["pending"] == []
+    audit_types = {entry["type"] for entry in merged["audit"]}
+    assert "conflict" in audit_types
+
+    final_items = {item["ticker"]: item for item in merged["items"]}
+    assert final_items["AAPL"]["note"] == "server-wins"
+    assert not final_items["AAPL"].get("pending", False)


### PR DESCRIPTION
## Summary
- add a progressive web client with IndexedDB-backed mutation queue, audit log UI, and service worker caching for API responses
- expose the static shell, manifest, service worker, and annotation endpoints from the FastAPI app for offline/online reconciliation
- document the offline workflow, register the e2e pytest marker, and add Playwright dependencies plus a browser test that exercises conflict resolution

## Testing
- ruff check src/highest_volatility/app/api.py tests/test_pwa_offline.py
- pytest tests/test_pwa_offline.py --browser chromium *(fails: missing Playwright system dependencies such as libatk1.0-0t64; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d7e98edc8328b1d1180cafddb629