### PR TITLE
Fix daily price fetch tickers array handling

### DIFF
--- a/.github/workflows/daily-price-fetch.yml
+++ b/.github/workflows/daily-price-fetch.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Fetch prices with retry
         run: |
           intervals=(1m 5m 15m 30m 1h 1d)
-          tickers="AAPL MSFT AMZN GOOGL META"
+          tickers=(AAPL MSFT AMZN GOOGL META)
           for intv in "${intervals[@]}"; do
-            until python -m highest_volatility.cli --interval "$intv" --tickers $tickers; do
+            until python -m highest_volatility.cli --interval "$intv" --tickers "${tickers[@]}"; do
               echo "Retrying $intv..."
               sleep 30
             done


### PR DESCRIPTION
## Summary
- treat the GitHub Actions ticker list as an array instead of a single string
- pass the tickers array to the CLI so argparse receives separate symbols

## Testing
- python -m highest_volatility.cli --interval 1d --tickers AAPL MSFT --top-n 2 --print-top 1 --lookback-days 5 --min-days 1 --no-validate-universe --tickers-cache-days 1

------
https://chatgpt.com/codex/tasks/task_e_68d1ddcddd408328b26b1d987bf4e0d9