### PR TITLE
Fix timezone handling for trim_start filtering

### DIFF
--- a/src/highest_volatility/ingest/prices.py
+++ b/src/highest_volatility/ingest/prices.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta, date, timezone
 from typing import Dict, List
 from contextlib import contextmanager
 import logging
@@ -68,7 +68,7 @@ def download_price_history(
         Raw DataFrame as returned by :func:`yfinance.download`.
     """
 
-    end_dt = datetime.utcnow()
+    end_dt = datetime.now(timezone.utc)
     start_dt = end_dt - timedelta(days=lookback_days * 2)
 
     def _download(*args, **kwargs):

--- a/tests/test_downloaders_timezone.py
+++ b/tests/test_downloaders_timezone.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from datetime import datetime
+
+from highest_volatility.ingest import downloaders
+
+
+def test_build_combined_dataframe_trims_naive_start_with_tz_index():
+    tz_index = pd.date_range(
+        "2024-01-01 09:30",
+        periods=4,
+        freq="15min",
+        tz="US/Eastern",
+    )
+    frames = {
+        "AAA": pd.DataFrame({"Adj Close": [1.0, 1.1, 1.2, 1.3]}, index=tz_index)
+    }
+
+    trim_start = datetime(2024, 1, 1, 9, 45)
+
+    combined = downloaders.build_combined_dataframe(frames, trim_start=trim_start)
+
+    assert not combined.empty
+    assert combined.index[0] == pd.Timestamp(trim_start, tz=tz_index.tz)
+    # Ensure earlier timestamps were trimmed
+    assert pd.Timestamp("2024-01-01 09:30", tz=tz_index.tz) not in combined.index
+
+
+def test_build_combined_dataframe_trim_beyond_range_returns_empty():
+    tz_index = pd.date_range(
+        "2024-01-01 09:30",
+        periods=2,
+        freq="15min",
+        tz="UTC",
+    )
+    frames = {
+        "AAA": pd.DataFrame({"Adj Close": [1.0, 1.1]}, index=tz_index)
+    }
+
+    trim_start = datetime(2024, 1, 1, 10, 0)
+
+    combined = downloaders.build_combined_dataframe(frames, trim_start=trim_start)
+
+    assert combined.empty


### PR DESCRIPTION
## Summary
- make price history downloads use UTC-aware datetime boundaries
- align trim_start filtering with dataframe index timezones across batch/async helpers
- add regression coverage ensuring tz-aware intraday frames trim correctly

## Testing
- `pytest tests/test_downloaders_timezone.py`
- `ruff check`
- `pytest` *(fails: missing optional dependency `playwright` during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e055b9088328a7f18e608b5b1b81