### PR TITLE
Handle corrupt cache manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ their imports to the ``highest_volatility.*`` modules before upgrading.
 The price cache manifest format is now at version ``2``. Existing
 ``cache/prices`` entries created with older releases are automatically deleted
 when accessed so fresh parquet and manifest files can be regenerated without
-manual cleanup.
+manual cleanup. Corrupt manifest files are also purged on load so the
+downloader can rebuild them without manual intervention.
 
 ## Data API
 


### PR DESCRIPTION
## Summary
- guard cache manifest parsing and purge corrupt entries so downloaders refresh cleanly
- add regression coverage for corrupt manifests and update cache documentation

## Testing
- pytest *(fails: existing suite hits environment-dependent browser/session_state assumptions and cache policy regressions unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d2db6763a08328aab24d344c99a9d4